### PR TITLE
Midi clock

### DIFF
--- a/avr/cores/megacommand/Midi/MidiClock.h
+++ b/avr/cores/megacommand/Midi/MidiClock.h
@@ -47,9 +47,9 @@ public:
   volatile uint8_t mod3_counter;
 
   volatile uint8_t mod8_free_counter;
-  volatile uint16_t div128_counter;
-  volatile uint16_t div128_time;
-  volatile uint8_t div128th_countdown;
+  volatile uint16_t div196_counter;
+  volatile uint16_t div196_time;
+  volatile uint8_t div196th_countdown;
   volatile uint16_t clock_last_time;
 
   volatile uint16_t last_diff_clock8;
@@ -260,7 +260,7 @@ public:
     // }
     clock_last_time = clock;
     uint8_t _mod6_counter = mod6_counter;
-    div128th_countdown = 0; 
+    div196th_countdown = 0; 
     if (transmit_uart1) {
       //       MidiUart.putc(0xF8);
       MidiUart.m_putc_immediate(0xF8);
@@ -317,7 +317,7 @@ public:
     if (mod8_free_counter == 8) {
       diff_clock8 = midi_clock_diff(last_clock8, clock);
       last_clock8 = clock;
-      div128_time = diff_clock8 / 16;
+      div196_time = diff_clock8 / 16;
       mod8_free_counter = 0;
     }
    if (state == STARTED) {

--- a/avr/cores/megacommand/Midi/MidiClock.h
+++ b/avr/cores/megacommand/Midi/MidiClock.h
@@ -50,7 +50,7 @@ public:
   volatile uint8_t mod4_free_counter;
   volatile uint16_t div128_counter;
   volatile uint16_t div128_time;
-   
+  volatile uint8_t div128th_countdown;
   volatile uint16_t clock_last_time;
 
   volatile uint16_t last_diff_clock4;
@@ -261,7 +261,7 @@ public:
     // }
     clock_last_time = clock;
     uint8_t _mod6_counter = mod6_counter;
-
+    div128th_countdown = 0; 
     if (transmit_uart1) {
       //       MidiUart.putc(0xF8);
       MidiUart.m_putc_immediate(0xF8);

--- a/avr/cores/megacommand/Midi/MidiClock.h
+++ b/avr/cores/megacommand/Midi/MidiClock.h
@@ -46,14 +46,16 @@ public:
   volatile uint8_t mod12_counter;
   volatile uint8_t mod6_counter;
   volatile uint8_t mod3_counter;
-  volatile uint8_t mod6_free_counter;
 
+  volatile uint8_t mod4_free_counter;
+  volatile uint16_t div128_counter;
+  volatile uint16_t div128_time;
+   
   volatile uint16_t clock_last_time;
-  volatile uint16_t div192th_time;
-  volatile uint16_t last_clock16;
 
-  volatile uint16_t last_diff_clock16;
-  volatile uint16_t diff_clock16;
+  volatile uint16_t last_diff_clock4;
+  volatile uint16_t diff_clock4;
+  volatile uint16_t last_clock4;
 
   volatile uint8_t bar_counter;
   volatile uint8_t beat_counter;
@@ -299,9 +301,10 @@ public:
   }
 
   void calc_tempo() {
-    if (last_diff_clock16 != diff_clock16) {
-      tempo = ((float)75000 / ((float)diff_clock16));
-      last_diff_clock16 = diff_clock16;
+    DEBUG_PRINTLN(diff_clock4);
+    if (last_diff_clock4 != diff_clock4) {
+      tempo = ((float)50000 / ((float)diff_clock4));
+      last_diff_clock4 = diff_clock4;
     }
   }
 
@@ -311,12 +314,12 @@ public:
   }
 
   ALWAYS_INLINE() void MidiClockClass::incrementCounters() {
-    mod6_free_counter++;
-    if (mod6_free_counter == 6) {
-      diff_clock16 = midi_clock_diff(last_clock16, clock);
-      div192th_time = diff_clock16 * .08333;
-      mod6_free_counter = 0;
-      last_clock16 = clock;
+    mod4_free_counter++;
+    if (mod4_free_counter == 4) {
+      diff_clock4 = midi_clock_diff(last_clock4, clock);
+      last_clock4 = clock;
+      div128_time = diff_clock4 / 8;
+      mod4_free_counter = 0;
     }
    if (state == STARTED) {
       div96th_counter++;

--- a/avr/cores/megacommand/Midi/MidiClock.h
+++ b/avr/cores/megacommand/Midi/MidiClock.h
@@ -1,4 +1,3 @@
-
 /* Copyright (c) 2009 - http://ruinwesen.com/ */
 
 #ifndef MIDICLOCK_H__
@@ -47,15 +46,15 @@ public:
   volatile uint8_t mod6_counter;
   volatile uint8_t mod3_counter;
 
-  volatile uint8_t mod4_free_counter;
+  volatile uint8_t mod8_free_counter;
   volatile uint16_t div128_counter;
   volatile uint16_t div128_time;
   volatile uint8_t div128th_countdown;
   volatile uint16_t clock_last_time;
 
-  volatile uint16_t last_diff_clock4;
-  volatile uint16_t diff_clock4;
-  volatile uint16_t last_clock4;
+  volatile uint16_t last_diff_clock8;
+  volatile uint16_t diff_clock8;
+  volatile uint16_t last_clock8;
 
   volatile uint8_t bar_counter;
   volatile uint8_t beat_counter;
@@ -301,10 +300,10 @@ public:
   }
 
   void calc_tempo() {
-    DEBUG_PRINTLN(diff_clock4);
-    if (last_diff_clock4 != diff_clock4) {
-      tempo = ((float)50000 / ((float)diff_clock4));
-      last_diff_clock4 = diff_clock4;
+    DEBUG_PRINTLN(diff_clock8);
+    if (last_diff_clock8 != diff_clock8) {
+      tempo = ((float)100000 / ((float)diff_clock8));
+      last_diff_clock8 = diff_clock8;
     }
   }
 
@@ -314,12 +313,12 @@ public:
   }
 
   ALWAYS_INLINE() void MidiClockClass::incrementCounters() {
-    mod4_free_counter++;
-    if (mod4_free_counter == 4) {
-      diff_clock4 = midi_clock_diff(last_clock4, clock);
-      last_clock4 = clock;
-      div128_time = diff_clock4 / 8;
-      mod4_free_counter = 0;
+    mod8_free_counter++;
+    if (mod8_free_counter == 8) {
+      diff_clock8 = midi_clock_diff(last_clock8, clock);
+      last_clock8 = clock;
+      div128_time = diff_clock8 / 16;
+      mod8_free_counter = 0;
     }
    if (state == STARTED) {
       div96th_counter++;

--- a/avr/cores/megacommand/main.cpp
+++ b/avr/cores/megacommand/main.cpp
@@ -195,12 +195,12 @@ ISR(TIMER1_COMPA_vect) {
   select_bank(0);
 
   clock++;
-  MidiClock.div128th_countdown++;
+  MidiClock.div196th_countdown++;
   if (MidiClock.state == 2) {
-  if (MidiClock.div128th_countdown >= MidiClock.div128_time) {
+  if (MidiClock.div196th_countdown >= MidiClock.div196_time) {
       if (MidiClock.div192th_counter != MidiClock.div192th_counter_last) {
       MidiClock.increment192Counter();
-      MidiClock.div128th_countdown = 0; 
+      MidiClock.div196th_countdown = 0; 
       MidiClock.div192th_counter_last = MidiClock.div192th_counter;
       if ((enable_clock_callbacks)) {
         MidiClock.callCallbacks();

--- a/avr/cores/megacommand/main.cpp
+++ b/avr/cores/megacommand/main.cpp
@@ -195,12 +195,10 @@ ISR(TIMER1_COMPA_vect) {
   select_bank(0);
 
   clock++;
-  MidiClock.div128_counter++;
 
-  if (MidiClock.div128_counter >= MidiClock.div128_time) {
-      MidiClock.div128_counter = 0;
-      if (MidiClock.state == 2) {
-              if (MidiClock.div192th_counter != MidiClock.div192th_counter_last) {
+  if (MidiClock.state == 2) {
+  if (clock_diff(MidiClock.clock_last_time, clock) >= MidiClock.div128_time) {
+      if (MidiClock.div192th_counter != MidiClock.div192th_counter_last) {
       MidiClock.increment192Counter();
       MidiClock.div192th_counter_last = MidiClock.div192th_counter;
       if ((enable_clock_callbacks)) {

--- a/avr/cores/megacommand/main.cpp
+++ b/avr/cores/megacommand/main.cpp
@@ -195,9 +195,12 @@ ISR(TIMER1_COMPA_vect) {
   select_bank(0);
 
   clock++;
-  if (MidiClock.state == 2) {
-  if (clock_diff(MidiClock.clock_last_time, clock) >= MidiClock.div192th_time) {
-      if (MidiClock.div192th_counter != MidiClock.div192th_counter_last) {
+  MidiClock.div128_counter++;
+
+  if (MidiClock.div128_counter >= MidiClock.div128_time) {
+      MidiClock.div128_counter = 0;
+      if (MidiClock.state == 2) {
+              if (MidiClock.div192th_counter != MidiClock.div192th_counter_last) {
       MidiClock.increment192Counter();
       MidiClock.div192th_counter_last = MidiClock.div192th_counter;
       if ((enable_clock_callbacks)) {
@@ -205,14 +208,6 @@ ISR(TIMER1_COMPA_vect) {
       }
     }
   }
-  /*
-  if (MidiClock.div96th_counter != MidiClock.div96th_counter_last) {
-    MidiClock.div96th_counter_last = MidiClock.div96th_counter;
-    if ((enable_clock_callbacks)) {
-            MidiClock.callCallbacks();
-    }
-  }
-  */
   }
 }
 

--- a/avr/cores/megacommand/main.cpp
+++ b/avr/cores/megacommand/main.cpp
@@ -195,11 +195,12 @@ ISR(TIMER1_COMPA_vect) {
   select_bank(0);
 
   clock++;
-
+  MidiClock.div128th_countdown++;
   if (MidiClock.state == 2) {
-  if (clock_diff(MidiClock.clock_last_time, clock) >= MidiClock.div128_time) {
+  if (MidiClock.div128th_countdown >= MidiClock.div128_time) {
       if (MidiClock.div192th_counter != MidiClock.div192th_counter_last) {
       MidiClock.increment192Counter();
+      MidiClock.div128th_countdown = 0; 
       MidiClock.div192th_counter_last = MidiClock.div192th_counter;
       if ((enable_clock_callbacks)) {
         MidiClock.callCallbacks();


### PR DESCRIPTION
By counting to 4 instead of 6, 

div128_time = time_for_4_pulses / 8 

which can be calculated by shifting instead of rcall and eliminate floating point operation.

Will probably save 1000 cycles.