### PR TITLE
Chromatic Page Bug Fixes.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,21 @@
+MCL 2.62 08/05/202
+
+Changes:
+
+  - Add transpose parameter to Chromatic Page. Accessible from Track Select Menu.
+
+Bug Fixes:
+
+  - Chromatic Page
+    * Note to PTC mapping was incorrect. (Wrong note displayed on keyboard,
+	machine base pitch not taken into consideration)
+    * Arpeggiator and Scales broken when using EXT MIDI. Fixed.
+    * Ext MIDI now responds from NOTE C2 and upwards. Scales are mapped across each note of keyboard and root is at C2.
+    * Poly config saved when exiting poly select page.
+    * Notes out of machine range, now result in silence, as opposed to playing highest note.
+    * Some tweaks to behaviour of the arpeggiator GUI.
+    * Clearing or adjusting length of poly tracks was broken.
+
 MCL 2.61 16/03/2020
 
 Changes:

--- a/avr/cores/megacommand/MCL/ArpPage.cpp
+++ b/avr/cores/megacommand/MCL/ArpPage.cpp
@@ -41,7 +41,7 @@ void ArpPage::loop() {
     seq_ptc_page.render_arp();
     }
   }
-  if (encoders[1]->hasChanged() || encoders[2]->hasChanged() ||
+  if (encoders[1]->hasChanged() ||
       encoders[3]->hasChanged()) {
     seq_ptc_page.render_arp();
   }

--- a/avr/cores/megacommand/MCL/MCL.h
+++ b/avr/cores/megacommand/MCL/MCL.h
@@ -91,8 +91,8 @@
 #include "Fonts/Elektrothic.h"
 #endif
 
-#define VERSION 2061
-#define VERSION_STR "2.61"
+#define VERSION 2062
+#define VERSION_STR "2.62"
 
 #define CALLBACK_TIMEOUT 500
 #define GUI_NAME_TIMEOUT 800

--- a/avr/cores/megacommand/MCL/PageSelectPage.cpp
+++ b/avr/cores/megacommand/MCL/PageSelectPage.cpp
@@ -34,7 +34,7 @@ const PageSelectEntry Entries[] PROGMEM = {
     {"STEP EDIT", &seq_step_page, 4, 1, 24, 25, (uint8_t *)icon_step},
     {"RECORD", &seq_rtrk_page, 5, 1, 24, 15, (uint8_t *)icon_rec},
     {"LOCKS", &seq_param_page[0], 6, 1, 24, 19, (uint8_t *)icon_para},
-    {"CHROMA", &seq_ptc_page, 7, 1, 24, 25, (uint8_t *)icon_chroma},
+    {"CHROMATIC", &seq_ptc_page, 7, 1, 24, 25, (uint8_t *)icon_chroma},
 #ifdef SOUND_PAGE
     {"SOUND MANAGER", &sound_browser, 8, 2, 24, 19, (uint8_t *)icon_sound},
 #endif
@@ -376,7 +376,7 @@ bool PageSelectPage::handleEvent(gui_event_t *event) {
     return true;
   }
 
-  if (EVENT_RELEASED(event, Buttons.BUTTON1)) {
+  if (EVENT_PRESSED(event, Buttons.BUTTON1)) {
     trig_interface.off();
     GUI.ignoreNextEvent(event->source);
     GUI.setPage(&grid_page);

--- a/avr/cores/megacommand/MCL/PolyPage.cpp
+++ b/avr/cores/megacommand/MCL/PolyPage.cpp
@@ -125,6 +125,7 @@ bool PolyPage::handleEvent(gui_event_t *event) {
   }
   if (EVENT_PRESSED(event, Buttons.BUTTON1) ||
       EVENT_PRESSED(event, Buttons.BUTTON4)) {
+    mcl_cfg.write_cfg();
     GUI.ignoreNextEvent(event->source);
     GUI.popPage();
     return true;

--- a/avr/cores/megacommand/MCL/SeqPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqPage.cpp
@@ -52,11 +52,12 @@ void SeqPage::init() {
 #endif
   toggle_device = true;
   seq_menu_page.menu.enable_entry(0, false);
-  if (mcl_cfg.track_select == 1) {
   seq_menu_page.menu.enable_entry(1, false);
+  if (mcl_cfg.track_select == 1) {
+  seq_menu_page.menu.enable_entry(2, false);
   }
   else {
-  seq_menu_page.menu.enable_entry(1, true);
+  seq_menu_page.menu.enable_entry(2, true);
   }
 }
 
@@ -912,14 +913,14 @@ void step_menu_handler() {
 
 void SeqPage::config_as_trackedit() {
 
-  seq_menu_page.menu.enable_entry(3, true);
-  seq_menu_page.menu.enable_entry(4, false);
+  seq_menu_page.menu.enable_entry(4, true);
+  seq_menu_page.menu.enable_entry(5, false);
 }
 
 void SeqPage::config_as_lockedit() {
 
-  seq_menu_page.menu.enable_entry(3, false);
-  seq_menu_page.menu.enable_entry(4, true);
+  seq_menu_page.menu.enable_entry(4, false);
+  seq_menu_page.menu.enable_entry(5, true);
 }
 
 void SeqPage::loop() {

--- a/avr/cores/megacommand/MCL/SeqPages.cpp
+++ b/avr/cores/megacommand/MCL/SeqPages.cpp
@@ -28,10 +28,11 @@ SeqPtcPage seq_ptc_page(&ptc_param_oct, &ptc_param_finetune, &ptc_param_len, &pt
 
 ArpPage arp_page(&arp_und, &arp_mode, &arp_speed, &arp_oct);
 
-const menu_t<9> seq_menu_layout PROGMEM = {
+const menu_t<10> seq_menu_layout PROGMEM = {
     "SEQ",
     {
         {"ARPEGGIATOR", 0, 0, 0, (uint8_t *)NULL, (Page *) &arp_page, NULL, {}},
+        {"TRANSPOSE:", 0, 12, 0, (uint8_t *)&seq_ptc_page.key, (Page *) NULL, NULL, {}},
         {"TRACK SEL:", 1, 17, 0, (uint8_t *)&opt_trackid, (Page *)NULL, opt_trackid_handler, {}},
         {"COPY:", 0, 3, 3, (uint8_t *)&opt_copy, (Page *)NULL, opt_copy_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"}}},
         {"CLEAR:", 0, 3, 3, (uint8_t *)&opt_clear, (Page *)NULL, opt_clear_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"}}},
@@ -46,7 +47,7 @@ const menu_t<9> seq_menu_layout PROGMEM = {
 
 MCLEncoder seq_menu_value_encoder(0, 16, ENCODER_RES_PAT);
 MCLEncoder seq_menu_entry_encoder(0, 9, ENCODER_RES_PAT);
-MenuPage<9> seq_menu_page(&seq_menu_layout, &seq_menu_value_encoder, &seq_menu_entry_encoder);
+MenuPage<10> seq_menu_page(&seq_menu_layout, &seq_menu_value_encoder, &seq_menu_entry_encoder);
 
 const menu_t<4> step_menu_layout PROGMEM = {
     "STP",

--- a/avr/cores/megacommand/MCL/SeqPages.h
+++ b/avr/cores/megacommand/MCL/SeqPages.h
@@ -56,7 +56,7 @@ extern ArpPage arp_page;
 
 extern MCLEncoder seq_menu_value_encoder;
 extern MCLEncoder seq_menu_entry_encoder;
-extern MenuPage<9> seq_menu_page;
+extern MenuPage<10> seq_menu_page;
 
 extern MCLEncoder step_menu_value_encoder;
 extern MCLEncoder step_menu_entry_encoder;

--- a/avr/cores/megacommand/MCL/SeqPtcPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqPtcPage.cpp
@@ -151,7 +151,9 @@ void SeqPtcPage::config() {
 
 void ptc_pattern_len_handler(Encoder *enc) {
   MCLEncoder *enc_ = (MCLEncoder *)enc;
+  bool is_poly = IS_BIT_SET16(mcl_cfg.poly_mask, last_md_track);
   if (SeqPage::midi_device == DEVICE_MD) {
+
 
     if (BUTTON_DOWN(Buttons.BUTTON3)) {
       for (uint8_t c = 0; c < 16; c++) {
@@ -159,7 +161,7 @@ void ptc_pattern_len_handler(Encoder *enc) {
       }
     } else {
 
-      if (seq_ptc_page.poly_count > 1) {
+      if ((seq_ptc_page.poly_max > 1) && (is_poly)) {
         for (uint8_t c = 0; c < 16; c++) {
           if (IS_BIT_SET16(mcl_cfg.poly_mask, c)) {
             mcl_seq.md_tracks[c].set_length(enc_->cur);
@@ -381,7 +383,7 @@ uint8_t SeqPtcPage::get_next_voice(uint8_t pitch) {
       }
     }
   }
-  // Reuse existing track for noew pitch
+  // Reuse existing track for new pitch
   for (uint8_t x = 0; x < 16 && voice == 255; x++) {
     if (MD.isMelodicTrack(x) && IS_BIT_SET16(mcl_cfg.poly_mask, x)) {
       if (count == poly_count) {
@@ -801,6 +803,8 @@ bool SeqPtcPage::handleEvent(gui_event_t *event) {
     queue_redraw();
   }
 
+  bool is_poly = IS_BIT_SET16(mcl_cfg.poly_mask, last_md_track);
+
   if (note_interface.is_event(event)) {
     uint8_t mask = event->mask;
     uint8_t port = event->port;
@@ -873,7 +877,7 @@ bool SeqPtcPage::handleEvent(gui_event_t *event) {
     }
     if (midi_device == DEVICE_MD) {
 
-      if (poly_count > 1) {
+      if ((poly_max > 1) && (is_poly)) {
 #ifdef OLED_DISPLAY
         oled_display.textbox("CLEAR ", "POLY TRACKS");
 #endif

--- a/avr/cores/megacommand/MCL/SeqPtcPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqPtcPage.cpp
@@ -88,6 +88,7 @@ void SeqPtcPage::init() {
   DEBUG_PRINT_FN();
   SeqPage::init();
   seq_menu_page.menu.enable_entry(0, true);
+  seq_menu_page.menu.enable_entry(1, true);
   ptc_param_len.handler = ptc_pattern_len_handler;
   recording = false;
   note_mask = 0;
@@ -153,7 +154,6 @@ void ptc_pattern_len_handler(Encoder *enc) {
   MCLEncoder *enc_ = (MCLEncoder *)enc;
   bool is_poly = IS_BIT_SET16(mcl_cfg.poly_mask, last_md_track);
   if (SeqPage::midi_device == DEVICE_MD) {
-
 
     if (BUTTON_DOWN(Buttons.BUTTON3)) {
       for (uint8_t c = 0; c < 16; c++) {
@@ -359,7 +359,7 @@ uint8_t SeqPtcPage::calc_scale_note(uint8_t note_num) {
   uint8_t oct = note_num / size;
   note_num = note_num - oct * size;
 
-  return scales[ptc_param_scale.cur]->pitches[note_num] + oct * 12;
+  return scales[ptc_param_scale.cur]->pitches[note_num] + oct * 12 + key;
 }
 
 uint8_t SeqPtcPage::get_next_voice(uint8_t pitch) {
@@ -955,8 +955,9 @@ void SeqPtcMidiEvents::onNoteOnCallback_Midi2(uint8_t *msg) {
   uint8_t oct = 0;
   if (note_num >= NOTE_C2) {
     oct = (note_num / 12) - (NOTE_C2 / 12);
+  } else {
+    return;
   }
-  else { return; }
   uint8_t pitch = seq_ptc_page.calc_scale_note(note + oct * 12);
 
   uint8_t scaled_pitch = pitch - (pitch / 24) * 24;
@@ -1019,8 +1020,7 @@ void SeqPtcMidiEvents::onNoteOffCallback_Midi2(uint8_t *msg) {
   uint8_t oct = 0;
   if (note_num >= NOTE_C2) {
     oct = (note_num / 12) - (NOTE_C2 / 12);
-  }
-  else {
+  } else {
     return;
   }
   uint8_t pitch = seq_ptc_page.calc_scale_note(note + oct * 12);

--- a/avr/cores/megacommand/MCL/SeqPtcPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqPtcPage.cpp
@@ -542,8 +542,7 @@ void SeqPtcPage::render_arp() {
   case ARP_RND:
     for (uint8_t i = 0; i < num_of_notes; i++) {
       note = sort_up[random(0, num_of_notes)];
-      arp_notes[arp_len++] =
-          calc_scale_note(note) + 12 * random(0, arp_oct.cur);
+      arp_notes[arp_len++] = note + 12 * random(0, arp_oct.cur);
     }
     break;
 
@@ -552,7 +551,7 @@ void SeqPtcPage::render_arp() {
   case ARP_UP:
     for (uint8_t i = 0; i < num_of_notes; i++) {
       note = sort_up[i];
-      arp_notes[i] = calc_scale_note(note);
+      arp_notes[i] = note;
       arp_len++;
     }
     break;
@@ -561,7 +560,7 @@ void SeqPtcPage::render_arp() {
   case ARP_DOWN:
     for (uint8_t i = 0; i < num_of_notes; i++) {
       note = sort_down[i];
-      arp_notes[i] = calc_scale_note(note);
+      arp_notes[i] = note;
       arp_len++;
     }
     break;
@@ -569,24 +568,24 @@ void SeqPtcPage::render_arp() {
   case ARP_UPDOWN:
     for (uint8_t i = 0; i < num_of_notes; i++) {
       note = sort_up[i];
-      arp_notes[i] = calc_scale_note(note);
+      arp_notes[i] = note;
       arp_len++;
     }
     for (uint8_t i = 1; i < num_of_notes - 1; i++) {
       note = sort_down[i];
-      arp_notes[arp_len] = calc_scale_note(note);
+      arp_notes[arp_len] = note;
       arp_len++;
     }
     break;
   case ARP_DOWNUP:
     for (uint8_t i = 0; i < num_of_notes; i++) {
       note = sort_down[i];
-      arp_notes[i] = calc_scale_note(note);
+      arp_notes[i] = note;
       arp_len++;
     }
     for (uint8_t i = 1; i < num_of_notes - 1; i++) {
       note = sort_up[i];
-      arp_notes[arp_len] = calc_scale_note(note);
+      arp_notes[arp_len] = note;
       arp_len++;
     }
 
@@ -594,24 +593,24 @@ void SeqPtcPage::render_arp() {
   case ARP_UPNDOWN:
     for (uint8_t i = 0; i < num_of_notes; i++) {
       note = sort_up[i];
-      arp_notes[i] = calc_scale_note(note);
+      arp_notes[i] = note;
       arp_len++;
     }
     for (uint8_t i = 0; i < num_of_notes; i++) {
       note = sort_down[i];
-      arp_notes[arp_len] = calc_scale_note(note);
+      arp_notes[arp_len] = note;
       arp_len++;
     }
     break;
   case ARP_DOWNNUP:
     for (uint8_t i = 0; i < num_of_notes; i++) {
       note = sort_down[i];
-      arp_notes[i] = calc_scale_note(note);
+      arp_notes[i] = note;
       arp_len++;
     }
     for (uint8_t i = 0; i < num_of_notes; i++) {
       note = sort_up[i];
-      arp_notes[arp_len] = calc_scale_note(note);
+      arp_notes[arp_len] = note;
       arp_len++;
     }
     break;
@@ -623,7 +622,7 @@ void SeqPtcPage::render_arp() {
       } else {
         note = sort_up[b];
       }
-      arp_notes[i] = calc_scale_note(note);
+      arp_notes[i] = note;
       arp_len++;
     }
     break;
@@ -635,7 +634,7 @@ void SeqPtcPage::render_arp() {
       } else {
         note = sort_down[b];
       }
-      arp_notes[i] = calc_scale_note(note);
+      arp_notes[i] = note;
       arp_len++;
     }
     break;
@@ -647,7 +646,7 @@ void SeqPtcPage::render_arp() {
       } else {
         note = sort_up[b];
       }
-      arp_notes[i] = calc_scale_note(note);
+      arp_notes[i] = note;
       arp_len++;
     }
     b = 0;
@@ -658,20 +657,20 @@ void SeqPtcPage::render_arp() {
       } else {
         note = sort_up[b];
       }
-      arp_notes[i] = calc_scale_note(note);
+      arp_notes[i] = note;
       arp_len++;
     }
     break;
   case ARP_PINKUP:
     if (num_of_notes == 1) {
       note = sort_up[0];
-      arp_notes[arp_len++] = calc_scale_note(note);
+      arp_notes[arp_len++] = note;
     }
     for (uint8_t i = 0; i < num_of_notes - 1; i++) {
       note = sort_up[i];
-      arp_notes[arp_len++] = calc_scale_note(note);
+      arp_notes[arp_len++] = note;
       note = sort_down[0];
-      arp_notes[arp_len++] = calc_scale_note(note);
+      arp_notes[arp_len++] = note;
     }
 
     break;
@@ -679,22 +678,22 @@ void SeqPtcPage::render_arp() {
   case ARP_PINKDOWN:
     for (uint8_t i = 1; i < num_of_notes; i++) {
       note = sort_down[i];
-      arp_notes[arp_len++] = calc_scale_note(note);
+      arp_notes[arp_len++] = note;
       note = sort_down[0];
-      arp_notes[arp_len++] = calc_scale_note(note);
+      arp_notes[arp_len++] = note;
     }
     break;
 
   case ARP_THUMBUP:
     if (num_of_notes == 1) {
       note = sort_down[0];
-      arp_notes[arp_len++] = calc_scale_note(note);
+      arp_notes[arp_len++] = note;
     }
     for (uint8_t i = 0; i < num_of_notes - 1; i++) {
       note = sort_up[i];
-      arp_notes[arp_len++] = calc_scale_note(note);
+      arp_notes[arp_len++] = note;
       note = sort_down[0];
-      arp_notes[arp_len++] = calc_scale_note(note);
+      arp_notes[arp_len++] = note;
     }
 
     break;
@@ -702,9 +701,9 @@ void SeqPtcPage::render_arp() {
   case ARP_THUMBDOWN:
     for (uint8_t i = 1; i < num_of_notes; i++) {
       note = sort_down[i];
-      arp_notes[arp_len++] = calc_scale_note(note);
+      arp_notes[arp_len++] = note;
       note = sort_down[0];
-      arp_notes[arp_len++] = calc_scale_note(note);
+      arp_notes[arp_len++] = note;
     }
     break;
   }

--- a/avr/cores/megacommand/MCL/SeqPtcPage.h
+++ b/avr/cores/megacommand/MCL/SeqPtcPage.h
@@ -55,6 +55,7 @@ class SeqPtcPage : public SeqPage, public ClockCallback {
 
 public:
   bool re_init = false;
+  uint8_t key = 0;
   uint8_t poly_count = 0;
   uint8_t poly_max = 0;
   uint8_t last_midi_state = 0;

--- a/avr/cores/megacommand/MCL/SeqPtcPage.h
+++ b/avr/cores/megacommand/MCL/SeqPtcPage.h
@@ -69,11 +69,11 @@ public:
       : SeqPage(e1, e2, e3, e4) {}
   uint8_t calc_poly_count();
   uint8_t seq_ext_pitch(uint8_t note_num);
-  uint8_t get_machine_pitch(uint8_t track, uint8_t pitch);
+  uint8_t get_machine_pitch(uint8_t track, uint8_t note_num);
   uint8_t get_next_voice(uint8_t pitch);
-  uint8_t calc_pitch(uint8_t note_num);
+  uint8_t calc_scale_note(uint8_t note_num);
 
-  void trig_md(uint8_t pitch);
+  void trig_md(uint8_t note_num);
   void trig_md_fromext(uint8_t note_num);
   void clear_trig_fromext(uint8_t note_num);
 


### PR DESCRIPTION
It should fix the following:

    Note to PTC mapping was incorrect. (Wrong note displayed on keyboard, machine base ptc not taken into consideration)
    Arpeggiator and Scales broken when using EXT MIDI. Fixed.
    Ext MIDI now responds from NOTE C2 and upwards. Scales are mapped across each note of keyboard and root is at C2.
    Poly config saved when exiting poly select page.
    Notes out of machine range, now result in silence, as opposed to playing highest note.
    Some tweaks to the arpeggiator GUI.

---

Also, I've noticed that MidiNotes.h definitions are incorrect.