### PR TITLE
Track Scales / Resolutions

### DIFF
--- a/avr/cores/megacommand/CommonTools/helpers.h
+++ b/avr/cores/megacommand/CommonTools/helpers.h
@@ -92,6 +92,16 @@ extern const uint32_t _bvmasks32[];
 #define IS_BIT_SET64(target, bit)           IS_BIT_SET_RADDR(target, bit)
 #define IS_BIT_CLEAR64(target, bit)         IS_BIT_CLEAR_RADDR(target, bit)
 
+/** 128-bit macros. **/
+#define SET_BIT128(target, bit)              SET_BIT_RADDR(target, bit)
+#define CLEAR_BIT128(target, bit)            CLEAR_BIT_RADDR(target, bit)
+#define TOGGLE_BIT128(target, bit)           TOGGLE_BIT_RADDR(target, bit)
+#define IS_BIT_SET128(target, bit)           IS_BIT_SET_RADDR(target, bit)
+#define IS_BIT_CLEAR128(target, bit)         IS_BIT_CLEAR_RADDR(target, bit)
+
+
+
+
 /** @} */
 
 /**

--- a/avr/cores/megacommand/MCL/A4Track.cpp
+++ b/avr/cores/megacommand/MCL/A4Track.cpp
@@ -5,7 +5,7 @@
 
 void A4Track::load_seq_data(int tracknumber) {
 #ifdef EXT_TRACKS
-  if (seq_data.scale == 0) { seq_data.scale = 1; }
+  if (seq_data.speed == 0) { seq_data.speed = EXT_SPEED_2X; }
   if (active == EMPTY_TRACK_TYPE) {
     mcl_seq.ext_tracks[tracknumber].clear_track();
   } else {

--- a/avr/cores/megacommand/MCL/A4Track.cpp
+++ b/avr/cores/megacommand/MCL/A4Track.cpp
@@ -5,7 +5,7 @@
 
 void A4Track::load_seq_data(int tracknumber) {
 #ifdef EXT_TRACKS
-  if (seq_data.resolution == 0) { seq_data.resolution = 1; }
+  if (seq_data.scale == 0) { seq_data.scale = 1; }
   if (active == EMPTY_TRACK_TYPE) {
     mcl_seq.ext_tracks[tracknumber].clear_track();
   } else {

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
@@ -212,7 +212,6 @@ void ExtSeqTrack::noteon_conditional(uint8_t condition, uint8_t note) {
 
 void ExtSeqTrack::set_ext_track_step(uint8_t step, uint8_t note_num,
                                      uint8_t velocity) {
-  DEBUG_PRINTLN("recording notes");
   uint8_t match = 255;
   // Look for matching note already on this step
   // If it's a note off, then disable the note
@@ -263,12 +262,8 @@ void ExtSeqTrack::record_ext_track_noteoff(uint8_t note_num, uint8_t velocity) {
                                      (mcl_actions.start_clock32th /
      scale)) / (length)));
  */
-  uint8_t utiming =
-      6 + MidiClock.mod12_counter - (6 * (MidiClock.mod12_counter / 6));
 
-  if (scale > 1) {
-    utiming = (MidiClock.mod12_counter + 12);
-  }
+  uint8_t utiming = (mod12_counter + get_timing_mid());
 
   uint8_t condition = 0;
   uint8_t match = 255;
@@ -303,19 +298,8 @@ void ExtSeqTrack::record_ext_track_noteoff(uint8_t note_num, uint8_t velocity) {
 }
 
 void ExtSeqTrack::record_ext_track_noteon(uint8_t note_num, uint8_t velocity) {
-  /*uint8_t step_count =
-      ((MidiClock.div32th_counter / scale) -
-       (mcl_actions.start_clock32th / scale)) -
-      (length * ((MidiClock.div32th_counter / scale -
-                                    (mcl_actions.start_clock32th /
-     scale)) / (length)));
-*/
-  uint8_t utiming =
-      6 + MidiClock.mod12_counter - (6 * (MidiClock.mod12_counter / 6));
 
-  if (scale > 1) {
-    utiming = (MidiClock.mod12_counter + 12);
-  }
+  uint8_t utiming = (mod12_counter + get_timing_mid());
   uint8_t condition = 0;
 
   uint8_t match = 255;

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
@@ -8,11 +8,11 @@ void ExtSeqTrack::set_length(uint8_t len) {
   }
   DEBUG_DUMP(step_count);
   /*uint8_t step_count =
-       ((MidiClock.div32th_counter / resolution) -
-        (mcl_actions.start_clock32th / resolution)) -
+       ((MidiClock.div32th_counter / scale) -
+        (mcl_actions.start_clock32th / scale)) -
        (length *
-        ((MidiClock.div32th_counter / resolution -
-          (mcl_actions.start_clock32th / resolution)) /
+        ((MidiClock.div32th_counter / scale -
+          (mcl_actions.start_clock32th / scale)) /
          (length)));
 */
 }
@@ -34,7 +34,7 @@ void ExtSeqTrack::seq() {
 
     uint8_t timing_counter = MidiClock.mod12_counter;
 
-    if ((resolution == 1)) {
+    if ((scale == 1)) {
       if (MidiClock.mod12_counter < 6) {
         timing_counter = MidiClock.mod12_counter;
       } else {
@@ -49,7 +49,7 @@ void ExtSeqTrack::seq() {
       next_step = step_count + 1;
     }
 
-    uint8_t timing_mid = 6 * resolution;
+    uint8_t timing_mid = 6 * scale;
     for (uint8_t c = 0; c < 4; c++) {
       uint8_t current_step;
       if (((timing[step_count] >= timing_mid) &&
@@ -68,9 +68,9 @@ void ExtSeqTrack::seq() {
     }
   }
   if (((MidiClock.mod12_counter == 11) || (MidiClock.mod12_counter == 5)) &&
-      (resolution == 1)) {
+      (scale == 1)) {
     step_count++;
-  } else if ((MidiClock.mod12_counter == 11) && (resolution == 2)) {
+  } else if ((MidiClock.mod12_counter == 11) && (scale == 2)) {
     step_count++;
   }
   if (step_count == length) {
@@ -224,16 +224,16 @@ void ExtSeqTrack::set_ext_track_step(uint8_t step, uint8_t note_num,
 }
 void ExtSeqTrack::record_ext_track_noteoff(uint8_t note_num, uint8_t velocity) {
   /* uint8_t step_count =
-       ((MidiClock.div32th_counter / resolution) -
-        (mcl_actions.start_clock32th / resolution)) -
-       (length * ((MidiClock.div32th_counter / resolution -
+       ((MidiClock.div32th_counter / scale) -
+        (mcl_actions.start_clock32th / scale)) -
+       (length * ((MidiClock.div32th_counter / scale -
                                      (mcl_actions.start_clock32th /
-     resolution)) / (length)));
+     scale)) / (length)));
  */
   uint8_t utiming =
       6 + MidiClock.mod12_counter - (6 * (MidiClock.mod12_counter / 6));
 
-  if (resolution > 1) {
+  if (scale > 1) {
     utiming = (MidiClock.mod12_counter + 12);
   }
 
@@ -271,16 +271,16 @@ void ExtSeqTrack::record_ext_track_noteoff(uint8_t note_num, uint8_t velocity) {
 
 void ExtSeqTrack::record_ext_track_noteon(uint8_t note_num, uint8_t velocity) {
   /*uint8_t step_count =
-      ((MidiClock.div32th_counter / resolution) -
-       (mcl_actions.start_clock32th / resolution)) -
-      (length * ((MidiClock.div32th_counter / resolution -
+      ((MidiClock.div32th_counter / scale) -
+       (mcl_actions.start_clock32th / scale)) -
+      (length * ((MidiClock.div32th_counter / scale -
                                     (mcl_actions.start_clock32th /
-     resolution)) / (length)));
+     scale)) / (length)));
 */
   uint8_t utiming =
       6 + MidiClock.mod12_counter - (6 * (MidiClock.mod12_counter / 6));
 
-  if (resolution > 1) {
+  if (scale > 1) {
     utiming = (MidiClock.mod12_counter + 12);
   }
   uint8_t condition = 0;

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
@@ -107,7 +107,7 @@ void ExtSeqTrack::noteon_conditional(uint8_t condition, uint8_t note) {
   switch (condition) {
   case 0:
   case 1:
-    if (!IS_BIT_SET64(oneshot_mask, step_count)) {
+    if (!IS_BIT_SET128(oneshot_mask, step_count)) {
       note_on(note);
     }
     break;
@@ -164,8 +164,8 @@ void ExtSeqTrack::noteon_conditional(uint8_t condition, uint8_t note) {
     }
     break;
   case 14:
-    if (!IS_BIT_SET64(oneshot_mask, step_count)) {
-      SET_BIT64(oneshot_mask, step_count);
+    if (!IS_BIT_SET128(oneshot_mask, step_count)) {
+      SET_BIT128(oneshot_mask, step_count);
       note_on(note);
     }
   }
@@ -336,7 +336,8 @@ void ExtSeqTrack::rotate_left() {
   for (uint8_t a = 0; a < 4; a++) {
     lock_masks[a] = 0;
   }
-  oneshot_mask = 0;
+  oneshot_mask[0] = 0;
+  oneshot_mask[1] = 0;
 
   for (uint8_t n = 0; n < length; n++) {
     if (n == 0) {
@@ -368,7 +369,8 @@ void ExtSeqTrack::rotate_right() {
   for (uint8_t a = 0; a < 4; a++) {
     lock_masks[a] = 0;
   }
-  oneshot_mask = 0;
+  oneshot_mask[0] = 0;
+  oneshot_mask[1] = 0;
 
   for (uint8_t n = 0; n < length; n++) {
     if (n == length - 1) {
@@ -401,7 +403,8 @@ void ExtSeqTrack::reverse() {
   for (uint8_t a = 0; a < 4; a++) {
     lock_masks[a] = 0;
   }
-  oneshot_mask = 0;
+  oneshot_mask[0] = 0;
+  oneshot_mask[1] = 0;
 
   for (uint8_t n = 0; n < length; n++) {
     new_pos = length - n - 1;

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
@@ -61,15 +61,8 @@ void ExtSeqTrack::set_length(uint8_t len) {
     step_count = length % step_count;
   }
   DEBUG_DUMP(step_count);
-  /*uint8_t step_count =
-       ((MidiClock.div32th_counter / scale) -
-        (mcl_actions.start_clock32th / scale)) -
-       (length *
-        ((MidiClock.div32th_counter / scale -
-          (mcl_actions.start_clock32th / scale)) /
-         (length)));
-*/
 }
+
 void ExtSeqTrack::seq() {
   if (mute_until_start) {
 
@@ -255,14 +248,6 @@ void ExtSeqTrack::set_ext_track_step(uint8_t step, uint8_t note_num,
   }
 }
 void ExtSeqTrack::record_ext_track_noteoff(uint8_t note_num, uint8_t velocity) {
-  /* uint8_t step_count =
-       ((MidiClock.div32th_counter / scale) -
-        (mcl_actions.start_clock32th / scale)) -
-       (length * ((MidiClock.div32th_counter / scale -
-                                     (mcl_actions.start_clock32th /
-     scale)) / (length)));
- */
-
   uint8_t utiming = (mod12_counter + get_timing_mid());
 
   uint8_t condition = 0;

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
@@ -67,7 +67,7 @@ void ExtSeqTrack::seq() {
   if (mute_until_start) {
 
     if (clock_diff(MidiClock.div16th_counter, start_step) == 0) {
-      init();
+      reset();
     }
   }
   uint8_t timing_mid = get_timing_mid();

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
@@ -1,6 +1,36 @@
 #include "ExtSeqTrack.h"
 #include "MCL.h"
 
+
+float ExtSeqTrack::get_scale_multiplier(uint8_t scale) {
+    float multi;
+    switch (scale) {
+    default:
+    case EXT_SCALE_1X:
+      multi = 1;
+      break;
+    case EXT_SCALE_2X:
+      multi = 0.5;
+      break;
+    case EXT_SCALE_3_4X:
+      multi = (4.0/3.0);
+      break;
+    case EXT_SCALE_3_2X:
+      multi = (3.0/2.0);
+      break;
+    }
+    return multi;
+}
+
+void ExtSeqTrack::set_scale(uint8_t _scale) {
+    uint8_t old_scale = scale;
+    for (uint8_t i = 0; i < 128; i++) {
+       timing[i] = round(get_scale_multiplier(scale) * ((float) timing[i] / get_scale_multiplier(old_scale)));
+    }
+    scale = _scale;
+}
+
+
 void ExtSeqTrack::set_length(uint8_t len) {
   length = len;
   if (step_count >= length) {

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
@@ -16,11 +16,11 @@ float ExtSeqTrack::get_scale_multiplier(uint8_t scale, bool inverse) {
     if (inverse) { multi = 2; }
     else { multi = 0.5; }
     break;
-  case EXT_SCALE_3_2X:
+  case EXT_SCALE_3_4X:
     if (inverse) { multi = 3.0 / 4.0; }
     else { multi = (4.0 / 3.0); }
     break;
-  case EXT_SCALE_3_4X:
+  case EXT_SCALE_3_2X:
     if (inverse) { multi = 3.0 / 2.0; }
     else { multi = (2.0 / 3.0); }
     break;

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
@@ -1,38 +1,38 @@
 #include "ExtSeqTrack.h"
 #include "MCL.h"
 
-float ExtSeqTrack::get_scale_multiplier(bool inverse) {
-  return get_scale_multiplier(scale, inverse);
+float ExtSeqTrack::get_speed_multiplier(bool inverse) {
+  return get_speed_multiplier(speed, inverse);
 }
 
-float ExtSeqTrack::get_scale_multiplier(uint8_t scale, bool inverse) {
+float ExtSeqTrack::get_speed_multiplier(uint8_t speed, bool inverse) {
   float multi;
-  switch (scale) {
+  switch (speed) {
   default:
-  case EXT_SCALE_1X:
+  case EXT_SPEED_1X:
     multi = 1;
     break;
-  case EXT_SCALE_2X:
+  case EXT_SPEED_2X:
     if (inverse) { multi = 2; }
     else { multi = 0.5; }
     break;
-  case EXT_SCALE_3_4X:
+  case EXT_SPEED_3_4X:
     if (inverse) { multi = 3.0 / 4.0; }
     else { multi = (4.0 / 3.0); }
     break;
-  case EXT_SCALE_3_2X:
+  case EXT_SPEED_3_2X:
     if (inverse) { multi = 3.0 / 2.0; }
     else { multi = (2.0 / 3.0); }
     break;
-  case EXT_SCALE_1_2X:
+  case EXT_SPEED_1_2X:
     if (inverse) { multi = 1.0 / 2.0; }
     else { multi = 2.0; }
     break;
-  case EXT_SCALE_1_4X:
+  case EXT_SPEED_1_4X:
     if (inverse) { multi = 1.0 / 4.0; }
     else { multi = 4.0; }
     break;
-  case EXT_SCALE_1_8X:
+  case EXT_SPEED_1_8X:
     if (inverse) { multi = 1.0 / 8.0; }
     else { multi = 8.0; }
     break;
@@ -40,13 +40,13 @@ float ExtSeqTrack::get_scale_multiplier(uint8_t scale, bool inverse) {
   return multi;
 }
 
-void ExtSeqTrack::set_scale(uint8_t _scale) {
-  uint8_t old_scale = scale;
-  float mult = get_scale_multiplier(_scale) / get_scale_multiplier(old_scale);
+void ExtSeqTrack::set_speed(uint8_t _speed) {
+  uint8_t old_speed = speed;
+  float mult = get_speed_multiplier(_speed) / get_speed_multiplier(old_speed);
   for (uint8_t i = 0; i < 128; i++) {
     timing[i] = round(mult * (float)timing[i]);
   }
-  scale = _scale;
+  speed = _speed;
   uint8_t timing_mid = get_timing_mid();
   if (mod12_counter > timing_mid) {
   mod12_counter = mod12_counter - (mod12_counter / timing_mid) * timing_mid;

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.h
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.h
@@ -15,7 +15,7 @@
 class ExtSeqTrackData {
 public:
   uint8_t length;
-  uint8_t resolution; // Resolution = 2 / ExtPatternResolution
+  uint8_t scale; // Resolution = 2 / ExtPatternResolution
   uint8_t reserved[4];
   int8_t notes[4][128]; // 128 steps, up to 4 notes per step
   uint8_t locks[4][128];

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.h
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.h
@@ -12,6 +12,12 @@
 
 #define UART2_PORT 2
 
+// EXT Track scale
+#define ext_scale_1x 0
+#define ext_scale_2x 1
+#define ext_scale_3_4x 2
+#define ext_scale_3_2x 3
+
 class ExtSeqTrackData {
 public:
   uint8_t length;
@@ -36,7 +42,7 @@ public:
 
   uint64_t note_buffer[2] = {
       0}; // 2 x 64 bit masks to store state of 128 notes.
-  uint64_t oneshot_mask;
+  uint64_t oneshot_mask[2];
 
   uint8_t step_count;
   uint32_t start_step;
@@ -50,7 +56,8 @@ public:
 
   ALWAYS_INLINE() void init() {
     step_count = 0;
-    oneshot_mask = 0;
+    oneshot_mask[0] = 0;
+    oneshot_mask[1] = 0;
     mute_until_start = false;
     iterations_5 = 1;
     iterations_6 = 1;

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.h
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.h
@@ -131,7 +131,7 @@ public:
       timing_mid = 8; // 12 * (2.0/3.0);
       break;
     case EXT_SCALE_1_2X:
-      timing_mid = 16;
+      timing_mid = 24;
       break;
     case EXT_SCALE_1_4X:
       timing_mid = 48;

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.h
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.h
@@ -5,6 +5,7 @@
 
 #include "MidiUartParent.hh"
 //#include "MidiUart.h"
+#include "SeqTrack.h"
 #include "WProgram.h"
 #define SEQ_NOTEBUF_SIZE 8
 #define SEQ_MUTE_ON 1
@@ -123,10 +124,10 @@ public:
     case EXT_SCALE_2X:
       timing_mid = 6;
       break;
-    case EXT_SCALE_3_2X:
+    case EXT_SCALE_3_4X:
       timing_mid = 16; // 12 * (4.0/3.0);
       break;
-    case EXT_SCALE_3_4X:
+    case EXT_SCALE_3_2X:
       timing_mid = 8; // 12 * (2.0/3.0);
       break;
     case EXT_SCALE_1_2X:

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.h
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.h
@@ -13,23 +13,23 @@
 
 #define UART2_PORT 2
 
-// EXT Track scale
-#define EXT_SCALE_1X 2
-#define EXT_SCALE_2X 1
-#define EXT_SCALE_3_4X 3
-#define EXT_SCALE_3_2X 4
-#define EXT_SCALE_1_2X 5
-#define EXT_SCALE_1_4X 6
-#define EXT_SCALE_1_8X 7
+// EXT Track speed
+#define EXT_SPEED_1X 2
+#define EXT_SPEED_2X 1
+#define EXT_SPEED_3_4X 3
+#define EXT_SPEED_3_2X 4
+#define EXT_SPEED_1_2X 5
+#define EXT_SPEED_1_4X 6
+#define EXT_SPEED_1_8X 7
 
-const uint8_t ext_scales[7] PROGMEM = {
-    EXT_SCALE_1X,   EXT_SCALE_2X,   EXT_SCALE_3_4X, EXT_SCALE_3_2X,
-    EXT_SCALE_1_2X, EXT_SCALE_1_4X, EXT_SCALE_1_8X};
+const uint8_t ext_speeds[7] PROGMEM = {
+    EXT_SPEED_1X,   EXT_SPEED_2X,   EXT_SPEED_3_4X, EXT_SPEED_3_2X,
+    EXT_SPEED_1_2X, EXT_SPEED_1_4X, EXT_SPEED_1_8X};
 
 class ExtSeqTrackData {
 public:
   uint8_t length;
-  uint8_t scale; // Resolution = 2 / ExtPatternResolution
+  uint8_t speed; // Resolution = 2 / ExtPatternResolution
   uint8_t reserved[4];
   int8_t notes[4][128]; // 128 steps, up to 4 notes per step
   uint8_t locks[4][128];
@@ -116,27 +116,27 @@ public:
   void set_length(uint8_t len);
   ALWAYS_INLINE() uint8_t get_timing_mid() {
     uint8_t timing_mid;
-    switch (scale) {
+    switch (speed) {
     default:
-    case EXT_SCALE_1X:
+    case EXT_SPEED_1X:
       timing_mid = 12;
       break;
-    case EXT_SCALE_2X:
+    case EXT_SPEED_2X:
       timing_mid = 6;
       break;
-    case EXT_SCALE_3_4X:
+    case EXT_SPEED_3_4X:
       timing_mid = 16; // 12 * (4.0/3.0);
       break;
-    case EXT_SCALE_3_2X:
+    case EXT_SPEED_3_2X:
       timing_mid = 8; // 12 * (2.0/3.0);
       break;
-    case EXT_SCALE_1_2X:
+    case EXT_SPEED_1_2X:
       timing_mid = 24;
       break;
-    case EXT_SCALE_1_4X:
+    case EXT_SPEED_1_4X:
       timing_mid = 48;
       break;
-    case EXT_SCALE_1_8X:
+    case EXT_SPEED_1_8X:
       timing_mid = 96;
       break;
     }
@@ -197,9 +197,9 @@ public:
   void rotate_right();
   void reverse();
 
-  void set_scale(uint8_t _scale);
-  float get_scale_multiplier(bool inverse = false);
-  float get_scale_multiplier(uint8_t scale, bool inverse = false);
+  void set_speed(uint8_t _speed);
+  float get_speed_multiplier(bool inverse = false);
+  float get_speed_multiplier(uint8_t speed, bool inverse = false);
 };
 
 #endif /* EXTSEQTRACK_H__ */

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.h
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.h
@@ -63,7 +63,7 @@ public:
   uint8_t iterations_7;
   uint8_t iterations_8;
 
-  ALWAYS_INLINE() void init() {
+  ALWAYS_INLINE() void reset() {
     step_count = 0;
     oneshot_mask[0] = 0;
     oneshot_mask[1] = 0;

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.h
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.h
@@ -13,10 +13,10 @@
 #define UART2_PORT 2
 
 // EXT Track scale
-#define ext_scale_1x 0
-#define ext_scale_2x 1
-#define ext_scale_3_4x 2
-#define ext_scale_3_2x 3
+#define EXT_SCALE_1X 0
+#define EXT_SCALE_2X 1
+#define EXT_SCALE_3_4X 2
+#define EXT_SCALE_3_2X 3
 
 class ExtSeqTrackData {
 public:

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.h
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.h
@@ -135,6 +135,9 @@ public:
   void rotate_left();
   void rotate_right();
   void reverse();
+
+  void set_scale(uint8_t _scale);
+  float get_scale_multiplier(uint8_t scale);
 };
 
 #endif /* EXTSEQTRACK_H__ */

--- a/avr/cores/megacommand/MCL/ExtTrack.cpp
+++ b/avr/cores/megacommand/MCL/ExtTrack.cpp
@@ -8,7 +8,7 @@ bool ExtTrack::get_track_from_sysex(int tracknumber, uint8_t column) {
 }
 bool ExtTrack::load_seq_data(int tracknumber) {
 #ifdef EXT_TRACKS
-  if (seq_data.scale == 0) { seq_data.scale = 1; }
+  if (seq_data.speed == 0) { seq_data.speed = EXT_SPEED_2X; }
   memcpy(&mcl_seq.ext_tracks[tracknumber], &seq_data,
            sizeof(seq_data));
 #endif

--- a/avr/cores/megacommand/MCL/ExtTrack.cpp
+++ b/avr/cores/megacommand/MCL/ExtTrack.cpp
@@ -8,7 +8,7 @@ bool ExtTrack::get_track_from_sysex(int tracknumber, uint8_t column) {
 }
 bool ExtTrack::load_seq_data(int tracknumber) {
 #ifdef EXT_TRACKS
-  if (seq_data.resolution == 0) { seq_data.resolution = 1; }
+  if (seq_data.scale == 0) { seq_data.scale = 1; }
   memcpy(&mcl_seq.ext_tracks[tracknumber], &seq_data,
            sizeof(seq_data));
 #endif

--- a/avr/cores/megacommand/MCL/MCLActions.cpp
+++ b/avr/cores/megacommand/MCL/MCLActions.cpp
@@ -483,7 +483,7 @@ void MCLActions::send_tracks_to_devices() {
       }
 #ifdef EXT_TRACKS
       else {
-        if (mcl_seq.ext_tracks[n - NUM_MD_TRACKS].resolution == 2) {
+        if (mcl_seq.ext_tracks[n - NUM_MD_TRACKS].scale == 2) {
           next_transitions[n] =
               MidiClock.div16th_counter -
               (mcl_seq.ext_tracks[n - NUM_MD_TRACKS].step_count);

--- a/avr/cores/megacommand/MCL/MCLActions.cpp
+++ b/avr/cores/megacommand/MCL/MCLActions.cpp
@@ -482,14 +482,14 @@ void MCLActions::send_tracks_to_devices() {
       if (n < NUM_MD_TRACKS) {
         next_transitions[n] = MidiClock.div16th_counter -
                               (mcl_seq.md_tracks[n].step_count *
-                               mcl_seq.md_tracks[n].get_scale_multiplier());
+                               mcl_seq.md_tracks[n].get_speed_multiplier());
       }
 #ifdef EXT_TRACKS
       else {
         next_transitions[n] =
             MidiClock.div16th_counter -
             (mcl_seq.ext_tracks[n - NUM_MD_TRACKS].step_count *
-             mcl_seq.ext_tracks[n - NUM_MD_TRACKS].get_scale_multiplier());
+             mcl_seq.ext_tracks[n - NUM_MD_TRACKS].get_speed_multiplier());
       }
 #endif
       calc_next_slot_transition(n);
@@ -514,14 +514,14 @@ void MCLActions::calc_next_slot_transition(uint8_t n) {
 
   if (n < NUM_MD_TRACKS) {
     uint8_t l = mcl_seq.md_tracks[n].length;
-    uint8_t m = mcl_seq.md_tracks[n].get_scale_multiplier();
+    uint8_t m = mcl_seq.md_tracks[n].get_speed_multiplier();
     len = chains[n].loops * l * m + ( l - m * l);
 
    }
 #ifdef EXT_TRACKS
   else {
     uint8_t l = mcl_seq.ext_tracks[n - NUM_MD_TRACKS].length;
-    uint8_t m = mcl_seq.ext_tracks[n - NUM_MD_TRACKS].get_scale_multiplier();
+    uint8_t m = mcl_seq.ext_tracks[n - NUM_MD_TRACKS].get_speed_multiplier();
     len = chains[n].loops * l * m + ( l - m * l);
 
   }

--- a/avr/cores/megacommand/MCL/MCLGUI.cpp
+++ b/avr/cores/megacommand/MCL/MCLGUI.cpp
@@ -444,24 +444,22 @@ void MCLGUI::draw_microtiming(uint8_t scale, uint8_t timing) {
   uint8_t heights_len;
   uint8_t degrees = timing_mid * 2;
   uint8_t heights[16];
-  //Triplets
-
+  // Triplets
   if (scale == SEQ_SCALE_2X) {
-    uint8_t heights_lowres[6] = {12, 4, 6, 10, 4, 8};
+    uint8_t heights_lowres[6] = {11, 4, 6, 10, 4, 8};
     memcpy(&heights, &heights_lowres, 6);
     heights_len = 6;
-  }
-  if (scale == SEQ_SCALE_3_4X) {
-    uint8_t heights_triplets[16] = {12, 2, 4, 8, 6, 10, 6, 2, 10, 2, 6, 8, 10, 4, 6, 2};
+  } else if (scale == SEQ_SCALE_3_4X) {
+    uint8_t heights_triplets[16] = {11, 2, 4, 8, 6,  10, 6, 2,
+                                    10, 2, 6, 8, 10, 4,  6, 2};
     memcpy(&heights, &heights_triplets, 16);
     heights_len = 16;
-  }
-  if (scale == SEQ_SCALE_3_2X) {
-    uint8_t heights_triplets[8] = {12, 4, 8, 10, 2, 8, 4, 2};
-    memcpy(&heights, &heights_triplets, 8);
+  } else if (scale == SEQ_SCALE_3_2X) {
+    uint8_t heights_triplets2[8] = {11, 4, 8, 10, 2, 8, 4, 2};
+    memcpy(&heights, &heights_triplets2, 8);
     heights_len = 8;
   } else {
-    uint8_t heights_highres[12] = {12, 2, 4, 8, 6, 2, 10, 2, 6, 8, 4, 2};
+    uint8_t heights_highres[12] = {11, 2, 4, 8, 6, 2, 10, 2, 6, 8, 4, 2};
     memcpy(&heights, &heights_highres, 12);
     heights_len = 12;
   }
@@ -470,20 +468,39 @@ void MCLGUI::draw_microtiming(uint8_t scale, uint8_t timing) {
   uint8_t w = 96;
   uint8_t x_pos = 64 - (w / 2);
   uint8_t x_w = (w / (degrees));
-  uint8_t x = x_pos;
+  bool degree_scalar = false;
+  if (x_w == 0) {
+    x_w = 1;
+    degree_scalar = true;
+  }
 
-  oled_display.fillRect(8, 2, 128 - 16, 32 - 2, BLACK);
-  oled_display.drawRect(8 + 1, 2 + 1, 128 - 16 - 2, 32 - 2 - 2, WHITE);
+  uint8_t x = x_pos;
+  char K[4];
+  strcpy(K, "--");
+  K[3] = '\0';
+
+   if (timing == 0) {
+   } else if ((timing < timing_mid) && (timing != 0)) {
+     itoa(timing_mid - timing, K + 1, 10);
+   } else {
+     K[0] = '+';
+     itoa(timing - timing_mid, K + 1, 10);
+   }
+
+
+  oled_display.fillRect(8, 1, 128 - 16, 32 - 2, BLACK);
+  oled_display.drawRect(8 + 1, 1 + 1, 128 - 16 - 2, 32 - 2 - 2, WHITE);
 
   oled_display.setCursor(x_pos + 34, 10);
-  oled_display.print("uTIMING");
-
+  oled_display.print("uTIMING: ");
+  oled_display.print(K);
   oled_display.drawLine(x, y_pos + heights[0], x + w, y_pos + heights[0],
                         WHITE);
   for (uint8_t n = 0; n <= degrees; n++) {
     oled_display.drawLine(x, y_pos + heights[0], x,
                           y_pos + heights[0] - heights[a], WHITE);
     a++;
+
     if (n == timing) {
       oled_display.fillRect(x - 1, y_pos + heights[0] + 3, 3, 3, WHITE);
       oled_display.drawPixel(x, y_pos + heights[0] + 2, WHITE);
@@ -492,7 +509,13 @@ void MCLGUI::draw_microtiming(uint8_t scale, uint8_t timing) {
     if (a == heights_len) {
       a = 0;
     }
-    x += x_w;
+    if (degree_scalar) {
+      if (n % 2 == 0) {
+        x += x_w;
+      }
+    } else {
+      x += x_w;
+    }
   }
   oled_display.setFont(oldfont);
 #endif

--- a/avr/cores/megacommand/MCL/MCLGUI.cpp
+++ b/avr/cores/megacommand/MCL/MCLGUI.cpp
@@ -433,22 +433,22 @@ void MCLGUI::draw_light_encoder(uint8_t x, uint8_t y, uint8_t value,
 #endif
 }
 
-void MCLGUI::draw_microtiming(uint8_t resolution, uint8_t timing) {
+void MCLGUI::draw_microtiming(uint8_t scale, uint8_t timing) {
 #ifdef OLED_DISPLAY
   auto oldfont = oled_display.getFont();
   oled_display.setFont(&TomThumb);
 
   oled_display.setTextColor(WHITE);
-  if (resolution == 0) {
-    resolution = 1;
+  if (scale == 0) {
+    scale = 1;
   }
-  if (resolution > 2) {
-    resolution = 1;
+  if (scale > 2) {
+    scale = 1;
   }
-  uint8_t degrees = 24 / resolution;
+  uint8_t degrees = 24 / scale;
   uint8_t heights[12];
 
-  if (resolution == 1) {
+  if (scale == 1) {
     uint8_t heights_highres[12] = {12, 2, 4, 8, 6, 2, 10, 2, 6, 8, 4, 2};
     memcpy(&heights, &heights_highres, 12);
   } else {

--- a/avr/cores/megacommand/MCL/MCLGUI.cpp
+++ b/avr/cores/megacommand/MCL/MCLGUI.cpp
@@ -439,21 +439,31 @@ void MCLGUI::draw_microtiming(uint8_t scale, uint8_t timing) {
   oled_display.setFont(&TomThumb);
 
   oled_display.setTextColor(WHITE);
-  if (scale == 0) {
-    scale = 1;
-  }
-  if (scale > 2) {
-    scale = 1;
-  }
-  uint8_t degrees = 24 / scale;
-  uint8_t heights[12];
+  SeqTrack seq_track;
+  uint8_t timing_mid = seq_track.get_timing_mid(scale);
+  uint8_t heights_len;
+  uint8_t degrees = timing_mid * 2;
+  uint8_t heights[16];
+  //Triplets
 
-  if (scale == 1) {
-    uint8_t heights_highres[12] = {12, 2, 4, 8, 6, 2, 10, 2, 6, 8, 4, 2};
-    memcpy(&heights, &heights_highres, 12);
-  } else {
+  if (scale == SEQ_SCALE_2X) {
     uint8_t heights_lowres[6] = {12, 4, 6, 10, 4, 8};
     memcpy(&heights, &heights_lowres, 6);
+    heights_len = 6;
+  }
+  if (scale == SEQ_SCALE_3_4X) {
+    uint8_t heights_triplets[16] = {12, 2, 4, 8, 6, 10, 6, 2, 10, 2, 6, 8, 10, 4, 6, 2};
+    memcpy(&heights, &heights_triplets, 16);
+    heights_len = 16;
+  }
+  if (scale == SEQ_SCALE_3_2X) {
+    uint8_t heights_triplets[8] = {12, 4, 8, 10, 2, 8, 4, 2};
+    memcpy(&heights, &heights_triplets, 8);
+    heights_len = 8;
+  } else {
+    uint8_t heights_highres[12] = {12, 2, 4, 8, 6, 2, 10, 2, 6, 8, 4, 2};
+    memcpy(&heights, &heights_highres, 12);
+    heights_len = 12;
   }
   uint8_t y_pos = 11;
   uint8_t a = 0;
@@ -479,7 +489,7 @@ void MCLGUI::draw_microtiming(uint8_t scale, uint8_t timing) {
       oled_display.drawPixel(x, y_pos + heights[0] + 2, WHITE);
     }
 
-    if (a == degrees / 2) {
+    if (a == heights_len) {
       a = 0;
     }
     x += x_w;

--- a/avr/cores/megacommand/MCL/MCLGUI.cpp
+++ b/avr/cores/megacommand/MCL/MCLGUI.cpp
@@ -433,28 +433,28 @@ void MCLGUI::draw_light_encoder(uint8_t x, uint8_t y, uint8_t value,
 #endif
 }
 
-void MCLGUI::draw_microtiming(uint8_t scale, uint8_t timing) {
+void MCLGUI::draw_microtiming(uint8_t speed, uint8_t timing) {
 #ifdef OLED_DISPLAY
   auto oldfont = oled_display.getFont();
   oled_display.setFont(&TomThumb);
 
   oled_display.setTextColor(WHITE);
   SeqTrack seq_track;
-  uint8_t timing_mid = seq_track.get_timing_mid(scale);
+  uint8_t timing_mid = seq_track.get_timing_mid(speed);
   uint8_t heights_len;
   uint8_t degrees = timing_mid * 2;
   uint8_t heights[16];
   // Triplets
-  if (scale == SEQ_SCALE_2X) {
+  if (speed == SEQ_SPEED_2X) {
     uint8_t heights_lowres[6] = {11, 4, 6, 10, 4, 8};
     memcpy(&heights, &heights_lowres, 6);
     heights_len = 6;
-  } else if (scale == SEQ_SCALE_3_4X) {
+  } else if (speed == SEQ_SPEED_3_4X) {
     uint8_t heights_triplets[16] = {11, 2, 4, 8, 6,  10, 6, 2,
                                     10, 2, 6, 8, 10, 4,  6, 2};
     memcpy(&heights, &heights_triplets, 16);
     heights_len = 16;
-  } else if (scale == SEQ_SCALE_3_2X) {
+  } else if (speed == SEQ_SPEED_3_2X) {
     uint8_t heights_triplets2[8] = {11, 4, 8, 10, 2, 8, 4, 2};
     memcpy(&heights, &heights_triplets2, 8);
     heights_len = 8;

--- a/avr/cores/megacommand/MCL/MCLSeq.cpp
+++ b/avr/cores/megacommand/MCL/MCLSeq.cpp
@@ -22,7 +22,7 @@ void MCLSeq::setup() {
   for (uint8_t i = 0; i < num_md_tracks; i++) {
     md_tracks[i].track_number = i;
     md_tracks[i].set_length(16);
-    md_tracks[i].scale = 1;
+    md_tracks[i].speed = MD_SPEED_1X;
     md_tracks[i].mute_state = SEQ_MUTE_OFF;
   }
 #ifdef LFO_TRACKS
@@ -40,7 +40,7 @@ void MCLSeq::setup() {
   for (uint8_t i = 0; i < num_ext_tracks; i++) {
     ext_tracks[i].channel = i;
     ext_tracks[i].set_length(16);
-    ext_tracks[i].scale = 1;
+    ext_tracks[i].speed = EXT_SPEED_2X;
   }
 #endif
   //   MidiClock.addOnClockCallback(this,

--- a/avr/cores/megacommand/MCL/MCLSeq.cpp
+++ b/avr/cores/megacommand/MCL/MCLSeq.cpp
@@ -22,7 +22,7 @@ void MCLSeq::setup() {
   for (uint8_t i = 0; i < num_md_tracks; i++) {
     md_tracks[i].track_number = i;
     md_tracks[i].set_length(16);
-    md_tracks[i].resolution = 1;
+    md_tracks[i].scale = 1;
     md_tracks[i].mute_state = SEQ_MUTE_OFF;
   }
 #ifdef LFO_TRACKS
@@ -40,7 +40,7 @@ void MCLSeq::setup() {
   for (uint8_t i = 0; i < num_ext_tracks; i++) {
     ext_tracks[i].channel = i;
     ext_tracks[i].set_length(16);
-    ext_tracks[i].resolution = 1;
+    ext_tracks[i].scale = 1;
   }
 #endif
   //   MidiClock.addOnClockCallback(this,

--- a/avr/cores/megacommand/MCL/MCLSeq.cpp
+++ b/avr/cores/megacommand/MCL/MCLSeq.cpp
@@ -102,11 +102,11 @@ void MCLSeq::onMidiStartImmediateCallback() {
 #ifdef EXT_TRACKS
   for (uint8_t i = 0; i < num_ext_tracks; i++) {
     // ext_tracks[i].start_clock32th = 0;
-    ext_tracks[i].init();
+    ext_tracks[i].reset();
   }
 #endif
   for (uint8_t i = 0; i < num_md_tracks; i++) {
-    md_tracks[i].init();
+    md_tracks[i].reset();
   }
 #ifdef LFO_TRACKS
   for (uint8_t i = 0; i < num_lfo_tracks; i++) {

--- a/avr/cores/megacommand/MCL/MCLSeq.h
+++ b/avr/cores/megacommand/MCL/MCLSeq.h
@@ -14,6 +14,14 @@
 #define SEQ_MUTE_ON 1
 #define SEQ_MUTE_OFF 0
 
+#define SEQ_SCALE_1X 0
+#define SEQ_SCALE_2X 1
+#define SEQ_SCALE_3_4X 2
+#define SEQ_SCALE_3_2X 3
+#define SEQ_SCALE_1_2X 4
+#define SEQ_SCALE_1_4X 5
+#define SEQ_SCALE_1_8X 6
+
 class MCLSeqMidiEvents : public MidiCallback {
 public:
   bool state;

--- a/avr/cores/megacommand/MCL/MDSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.cpp
@@ -23,11 +23,11 @@ float MDSeqTrack::get_scale_multiplier(uint8_t scale, bool inverse) {
     if (inverse) { multi = 2; }
     else { multi = 0.5; }
     break;
-  case MD_SCALE_3_2X:
+  case MD_SCALE_3_4X:
     if (inverse) { multi = 3.0 / 4.0; }
     else { multi = (4.0 / 3.0); }
     break;
-  case MD_SCALE_3_4X:
+  case MD_SCALE_3_2X:
     if (inverse) { multi = 3.0 / 2.0; }
     else { multi = (2.0 / 3.0); }
     break;

--- a/avr/cores/megacommand/MCL/MDSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.cpp
@@ -8,7 +8,11 @@ void MDSeqTrack::set_length(uint8_t len) {
   }
 }
 
-float MDSeqTrack::get_scale_multiplier(uint8_t scale) {
+float MDSeqTrack::get_scale_multiplier(bool inverse) {
+  return get_scale_multiplier(scale, inverse);
+}
+
+float MDSeqTrack::get_scale_multiplier(uint8_t scale, bool inverse) {
   float multi;
   switch (scale) {
   default:
@@ -16,19 +20,28 @@ float MDSeqTrack::get_scale_multiplier(uint8_t scale) {
     multi = 1;
     break;
   case MD_SCALE_2X:
-    multi = 0.5;
+    if (inverse) { multi = 2; }
+    else { multi = 0.5; }
     break;
   case MD_SCALE_3_2X:
-    multi = (4.0 / 3.0);
+    if (inverse) { multi = 3.0 / 4.0; }
+    else { multi = (4.0 / 3.0); }
     break;
   case MD_SCALE_3_4X:
-    multi = (2.0 / 3.0);
+    if (inverse) { multi = 3.0 / 2.0; }
+    else { multi = (2.0 / 3.0); }
+    break;
+  case MD_SCALE_1_2X:
+    if (inverse) { multi = 1.0 / 2.0; }
+    else { multi = 2.0; }
     break;
   case MD_SCALE_1_4X:
-    multi = 4.0;
+    if (inverse) { multi = 1.0 / 4.0; }
+    else { multi = 4.0; }
     break;
   case MD_SCALE_1_8X:
-    multi = 8.0;
+    if (inverse) { multi = 1.0 / 8.0; }
+    else { multi = 8.0; }
     break;
   }
   return multi;
@@ -42,13 +55,10 @@ void MDSeqTrack::set_scale(uint8_t _scale) {
   }
   scale = _scale;
   uint8_t timing_mid = get_timing_mid();
-  USE_LOCK();
-  SET_LOCK();
   if (mod12_counter > timing_mid) {
   mod12_counter = mod12_counter - (mod12_counter / timing_mid) * timing_mid;
   //step_count_inc();
   }
-  CLEAR_LOCK();
 }
 
 void MDSeqTrack::seq() {

--- a/avr/cores/megacommand/MCL/MDSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.cpp
@@ -62,25 +62,9 @@ void MDSeqTrack::seq() {
 
     mod12_counter++;
 
-    uint8_t timing_mid;
+    uint8_t timing_mid = get_timing_mid();
 
-    switch (scale) {
-    default:
-    case MD_SCALE_1X:
-      timing_mid = 12;
-      break;
-    case MD_SCALE_2X:
-      timing_mid = 6;
-      break;
-    case MD_SCALE_3_4X:
-      timing_mid = 16 //12 * (4.0/3.0);
-      break;
-    case MD_SCALE_3_2X:
-      timing_mid = 8 //12 * (2.0/3.0);
-      break;
-    }
-
-     if (((timing[step_count] >= timing_mid) && (timing[step_count] - timing_mid == mod12_counter)) ||
+    if (((timing[step_count] >= timing_mid) && (timing[step_count] - timing_mid == mod12_counter)) ||
         ((timing[next_step] < timing_mid) && ((timing[next_step]) == mod12_counter))) {
       bool send_trig = false;
       send_trig = trig_conditional(conditional[current_step]);
@@ -97,7 +81,6 @@ void MDSeqTrack::seq() {
       mod12_counter = 0;
       step_count++;
     }
-    break;
   }
 
   if (step_count == length - 1) {

--- a/avr/cores/megacommand/MCL/MDSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.cpp
@@ -59,7 +59,8 @@ void MDSeqTrack::seq() {
 
       init();
     }
-  } else if ((MidiUart.uart_block == 0) && (mute_state == SEQ_MUTE_OFF)) {
+  }
+  if ((MidiUart.uart_block == 0) && (mute_until_start == false) && (mute_state == SEQ_MUTE_OFF)) {
 
     uint8_t next_step = 0;
     if (step_count == (length - 1)) {

--- a/avr/cores/megacommand/MCL/MDSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.cpp
@@ -8,38 +8,38 @@ void MDSeqTrack::set_length(uint8_t len) {
   }
 }
 
-float MDSeqTrack::get_scale_multiplier(bool inverse) {
-  return get_scale_multiplier(scale, inverse);
+float MDSeqTrack::get_speed_multiplier(bool inverse) {
+  return get_speed_multiplier(speed, inverse);
 }
 
-float MDSeqTrack::get_scale_multiplier(uint8_t scale, bool inverse) {
+float MDSeqTrack::get_speed_multiplier(uint8_t speed, bool inverse) {
   float multi;
-  switch (scale) {
+  switch (speed) {
   default:
-  case MD_SCALE_1X:
+  case MD_SPEED_1X:
     multi = 1;
     break;
-  case MD_SCALE_2X:
+  case MD_SPEED_2X:
     if (inverse) { multi = 2; }
     else { multi = 0.5; }
     break;
-  case MD_SCALE_3_4X:
+  case MD_SPEED_3_4X:
     if (inverse) { multi = 3.0 / 4.0; }
     else { multi = (4.0 / 3.0); }
     break;
-  case MD_SCALE_3_2X:
+  case MD_SPEED_3_2X:
     if (inverse) { multi = 3.0 / 2.0; }
     else { multi = (2.0 / 3.0); }
     break;
-  case MD_SCALE_1_2X:
+  case MD_SPEED_1_2X:
     if (inverse) { multi = 1.0 / 2.0; }
     else { multi = 2.0; }
     break;
-  case MD_SCALE_1_4X:
+  case MD_SPEED_1_4X:
     if (inverse) { multi = 1.0 / 4.0; }
     else { multi = 4.0; }
     break;
-  case MD_SCALE_1_8X:
+  case MD_SPEED_1_8X:
     if (inverse) { multi = 1.0 / 8.0; }
     else { multi = 8.0; }
     break;
@@ -47,13 +47,13 @@ float MDSeqTrack::get_scale_multiplier(uint8_t scale, bool inverse) {
   return multi;
 }
 
-void MDSeqTrack::set_scale(uint8_t _scale) {
-  uint8_t old_scale = scale;
-  float mult = get_scale_multiplier(_scale) / get_scale_multiplier(old_scale);
+void MDSeqTrack::set_speed(uint8_t _speed) {
+  uint8_t old_speed = speed;
+  float mult = get_speed_multiplier(_speed) / get_speed_multiplier(old_speed);
   for (uint8_t i = 0; i < NUM_MD_STEPS; i++) {
     timing[i] = round(mult * (float)timing[i]);
   }
-  scale = _scale;
+  speed = _speed;
   uint8_t timing_mid = get_timing_mid();
   if (mod12_counter > timing_mid) {
   mod12_counter = mod12_counter - (mod12_counter / timing_mid) * timing_mid;

--- a/avr/cores/megacommand/MCL/MDSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.cpp
@@ -22,7 +22,7 @@ float MDSeqTrack::get_scale_multiplier(uint8_t scale) {
     multi = (4.0 / 3.0);
     break;
   case MD_SCALE_3_2X:
-    multi = (3.0 / 2.0);
+    multi = (2.0 / 3.0);
     break;
   }
   return multi;
@@ -31,10 +31,10 @@ float MDSeqTrack::get_scale_multiplier(uint8_t scale) {
 void MDSeqTrack::set_scale(uint8_t _scale) {
   uint8_t old_scale = scale;
   for (uint8_t i = 0; i < NUM_MD_STEPS; i++) {
-    timing[i] = round(get_scale_multiplier(scale) *
-                      ((float)timing[i] / get_scale_multiplier(old_scale)));
+    timing[i] = round(get_scale_multiplier(_scale) * ((float)timing[i] / get_scale_multiplier(old_scale)));
   }
   scale = _scale;
+  init();
 }
 
 void MDSeqTrack::seq() {

--- a/avr/cores/megacommand/MCL/MDSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.cpp
@@ -338,11 +338,7 @@ void MDSeqTrack::set_track_locks(uint8_t step, uint8_t track_param,
   }
 }
 void MDSeqTrack::record_track_locks(uint8_t track_param, uint8_t value) {
-  /*
-    uint8_t step_count =
-        (MidiClock.div16th_counter - mcl_actions.start_clock32th / 2) -
-        (length * ((MidiClock.div16th_counter - mcl_actions.start_clock32th / 2)
-    / length));*/
+
   if (step_count >= length) {
     return;
   }
@@ -373,25 +369,18 @@ void MDSeqTrack::set_track_pitch(uint8_t step, uint8_t pitch) {
 }
 
 void MDSeqTrack::record_track_pitch(uint8_t pitch) {
-  /* uint8_t step_count =
-       (MidiClock.div16th_counter - mcl_actions.start_clock32th / 2) -
-       (length * ((MidiClock.div16th_counter - mcl_actions.start_clock32th / 2)
-     / length)); */
-  if (step_count >= length) {
+
+ if (step_count >= length) {
     return;
   }
   set_track_pitch(step_count, pitch);
 }
 void MDSeqTrack::record_track(uint8_t velocity) {
-  /*uint8_t step_count =
-       (MidiClock.div16th_counter - mcl_actions.start_clock32th / 2) -
-       (length * ((MidiClock.div16th_counter - mcl_actions.start_clock32th / 2)
-     / length)); */
 
   if (step_count >= length) {
     return;
   }
-  uint8_t utiming = MidiClock.mod12_counter + 12;
+  uint8_t utiming = mod12_counter + get_timing_mid();
   set_track_step(step_count, utiming, velocity);
 }
 

--- a/avr/cores/megacommand/MCL/MDSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.cpp
@@ -8,16 +8,6 @@ void MDSeqTrack::set_length(uint8_t len) {
   }
 }
 
-// MD Pattern scale
-//[0 = 1x, 1=2x, 2=3/4x, 3=3/2x]
-
-// MCL Track scale
-#define md_scale_1x 1
-#define md_scale_2x 0
-#define md_scale_3_4x 2
-#define md_scale_3_2x 3
-
-
 float MDSeqTrack::get_scale_multiplier(uint8_t scale) {
     float multi;
     switch (scale) {

--- a/avr/cores/megacommand/MCL/MDSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.cpp
@@ -12,16 +12,16 @@ float MDSeqTrack::get_scale_multiplier(uint8_t scale) {
     float multi;
     switch (scale) {
     default:
-    case md_scale_1x:
+    case MD_SCALE_1X:
       multi = 1;
       break;
-    case md_scale_2x:
+    case MD_SCALE_2X:
       multi = 0.5;
       break;
-    case md_scale_3_4x:
+    case MD_SCALE_3_4X:
       multi = (4.0/3.0);
       break;
-    case md_scale_3_2x:
+    case MD_SCALE_3_2X:
       multi = (3.0/2.0);
       break;
     }
@@ -66,16 +66,16 @@ void MDSeqTrack::seq() {
 
     switch (scale) {
     default:
-    case md_scale_1x:
+    case MD_SCALE_1X:
       timing_mid = 12;
       break;
-    case md_scale_2x:
+    case MD_SCALE_2X:
       timing_mid = 6;
       break;
-    case md_scale_3_4x:
+    case MD_SCALE_3_4X:
       timing_mid = 16 //12 * (4.0/3.0);
       break;
-    case md_scale_3_2x:
+    case MD_SCALE_3_2X:
       timing_mid = 8 //12 * (2.0/3.0);
       break;
     }

--- a/avr/cores/megacommand/MCL/MDSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.cpp
@@ -18,10 +18,10 @@ float MDSeqTrack::get_scale_multiplier(uint8_t scale) {
   case MD_SCALE_2X:
     multi = 0.5;
     break;
-  case MD_SCALE_3_4X:
+  case MD_SCALE_3_2X:
     multi = (4.0 / 3.0);
     break;
-  case MD_SCALE_3_2X:
+  case MD_SCALE_3_4X:
     multi = (2.0 / 3.0);
     break;
   }

--- a/avr/cores/megacommand/MCL/MDSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.cpp
@@ -71,7 +71,7 @@ void MDSeqTrack::seq() {
       DEBUG_PRINTLN(start_step);
       DEBUG_PRINTLN(MidiClock.mod12_counter);
 
-      init();
+      reset();
     }
   }
 
@@ -496,6 +496,7 @@ void MDSeqTrack::merge_from_md(MDTrack *md_track) {
   float swing = (float)md_track->kitextra.swingAmount / 16385.0;
 
   uint64_t swingpattern;
+  uint8_t timing_mid = get_timing_mid();
   if (md_track->kitextra.swingEditAll > 0) {
     swingpattern |= md_track->kitextra.swingPattern;
   } else {
@@ -504,10 +505,10 @@ void MDSeqTrack::merge_from_md(MDTrack *md_track) {
   for (uint8_t a = 0; a < length; a++) {
     if (IS_BIT_SET64(md_track->trigPattern, a)) {
       conditional[a] = 0;
-      timing[a] = 12;
+      timing[a] = timing_mid;
     }
     if (IS_BIT_SET64(swingpattern, a)) {
-      timing[a] = round(swing * 12.0) + 12;
+      timing[a] = round(swing * timing_mid) + timing_mid;
     }
   }
 }

--- a/avr/cores/megacommand/MCL/MDSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.cpp
@@ -9,32 +9,32 @@ void MDSeqTrack::set_length(uint8_t len) {
 }
 
 float MDSeqTrack::get_scale_multiplier(uint8_t scale) {
-    float multi;
-    switch (scale) {
-    default:
-    case MD_SCALE_1X:
-      multi = 1;
-      break;
-    case MD_SCALE_2X:
-      multi = 0.5;
-      break;
-    case MD_SCALE_3_4X:
-      multi = (4.0/3.0);
-      break;
-    case MD_SCALE_3_2X:
-      multi = (3.0/2.0);
-      break;
-    }
-    return multi;
+  float multi;
+  switch (scale) {
+  default:
+  case MD_SCALE_1X:
+    multi = 1;
+    break;
+  case MD_SCALE_2X:
+    multi = 0.5;
+    break;
+  case MD_SCALE_3_4X:
+    multi = (4.0 / 3.0);
+    break;
+  case MD_SCALE_3_2X:
+    multi = (3.0 / 2.0);
+    break;
+  }
+  return multi;
 }
 
-
 void MDSeqTrack::set_scale(uint8_t _scale) {
-    uint8_t old_scale = scale;
-    for (uint8_t i = 0; i < NUM_MD_STEPS; i++) {
-       timing[i] = round(get_scale_multiplier(scale) * ((float) timing[i] / get_scale_multiplier(old_scale)));
-    }
-    scale = _scale;
+  uint8_t old_scale = scale;
+  for (uint8_t i = 0; i < NUM_MD_STEPS; i++) {
+    timing[i] = round(get_scale_multiplier(scale) *
+                      ((float)timing[i] / get_scale_multiplier(old_scale)));
+  }
+  scale = _scale;
 }
 
 void MDSeqTrack::seq() {
@@ -50,7 +50,11 @@ void MDSeqTrack::seq() {
       init();
     }
   }
-  if ((MidiUart.uart_block == 0) && (mute_until_start == false) && (mute_state == SEQ_MUTE_OFF)) {
+
+  uint8_t timing_mid = get_timing_mid();
+
+  if ((MidiUart.uart_block == 0) && (mute_until_start == false) &&
+      (mute_state == SEQ_MUTE_OFF)) {
 
     uint8_t next_step = 0;
     if (step_count == (length - 1)) {
@@ -60,12 +64,10 @@ void MDSeqTrack::seq() {
     }
     uint8_t current_step;
 
-    mod12_counter++;
-
-    uint8_t timing_mid = get_timing_mid();
-
-    if (((timing[step_count] >= timing_mid) && (timing[step_count] - timing_mid == mod12_counter)) ||
-        ((timing[next_step] < timing_mid) && ((timing[next_step]) == mod12_counter))) {
+    if (((timing[step_count] >= timing_mid) &&
+         (timing[current_step = step_count] - timing_mid == mod12_counter)) ||
+        ((timing[next_step] < timing_mid) &&
+         ((timing[current_step = next_step]) == mod12_counter))) {
       bool send_trig = false;
       send_trig = trig_conditional(conditional[current_step]);
 
@@ -77,31 +79,35 @@ void MDSeqTrack::seq() {
         }
       }
     }
-    if (mod12_counter == timing_mid - 1) {
-      mod12_counter = 0;
-      step_count++;
-    }
   }
 
-  if (step_count == length - 1) {
-    step_count = 0;
+  mod12_counter++;
 
-    iterations_5++;
-    iterations_6++;
-    iterations_7++;
-    iterations_8++;
+  if (mod12_counter == timing_mid) {
+    mod12_counter = 0;
 
-    if (iterations_5 > 5) {
-      iterations_5 = 1;
-    }
-    if (iterations_6 > 6) {
-      iterations_8 = 1;
-    }
-    if (iterations_7 > 7) {
-      iterations_7 = 1;
-    }
-    if (iterations_8 > 8) {
-      iterations_8 = 1;
+    if (step_count == length - 1) {
+      step_count = 0;
+
+      iterations_5++;
+      iterations_6++;
+      iterations_7++;
+      iterations_8++;
+
+      if (iterations_5 > 5) {
+        iterations_5 = 1;
+      }
+      if (iterations_6 > 6) {
+        iterations_8 = 1;
+      }
+      if (iterations_7 > 7) {
+        iterations_7 = 1;
+      }
+      if (iterations_8 > 8) {
+        iterations_8 = 1;
+      }
+    } else {
+      step_count++;
     }
   }
 }

--- a/avr/cores/megacommand/MCL/MDSeqTrack.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.h
@@ -78,6 +78,9 @@ public:
   void rotate_right();
   void reverse();
 
+  float get_scale_multiplier(uint8_t scale);
+  void set_scale(uint8_t _scale);
+
   void copy_step(uint8_t n, MDSeqStep *step);
   void paste_step(uint8_t n, MDSeqStep *step);
 };

--- a/avr/cores/megacommand/MCL/MDSeqTrack.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.h
@@ -11,6 +11,15 @@
 #define SEQ_MUTE_ON 1
 #define SEQ_MUTE_OFF 0
 
+// MD Pattern scale
+//[0 = 1x, 1=2x, 2=3/4x, 3=3/2x]
+
+// MCL Track scale
+#define md_scale_1x 1
+#define md_scale_2x 0
+#define md_scale_3_4x 2
+#define md_scale_3_2x 3
+
 // forward declare MDTrack
 class MDTrack;
 

--- a/avr/cores/megacommand/MCL/MDSeqTrack.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.h
@@ -19,7 +19,12 @@
 #define MD_SCALE_2X 65
 #define MD_SCALE_3_4X 66
 #define MD_SCALE_3_2X 67
+#define MD_SCALE_1_4X 68
+#define MD_SCALE_1_8X 69
 
+const uint8_t md_scales[6] PROGMEM = {MD_SCALE_1X,   MD_SCALE_2X,
+                                      MD_SCALE_3_4X, MD_SCALE_3_2X,
+                                      MD_SCALE_1_4X, MD_SCALE_1_8X};
 // forward declare MDTrack
 class MDTrack;
 
@@ -66,6 +71,31 @@ public:
   }
 
   ALWAYS_INLINE() void seq();
+  ALWAYS_INLINE() void step_count_inc() {
+    if (step_count == length - 1) {
+      step_count = 0;
+
+      iterations_5++;
+      iterations_6++;
+      iterations_7++;
+      iterations_8++;
+
+      if (iterations_5 > 5) {
+        iterations_5 = 1;
+      }
+      if (iterations_6 > 6) {
+        iterations_8 = 1;
+      }
+      if (iterations_7 > 7) {
+        iterations_7 = 1;
+      }
+      if (iterations_8 > 8) {
+        iterations_8 = 1;
+      }
+    } else {
+      step_count++;
+    }
+  }
   void send_trig();
   ALWAYS_INLINE() void send_trig_inline();
   ALWAYS_INLINE() bool trig_conditional(uint8_t condition);
@@ -119,6 +149,12 @@ public:
       break;
     case MD_SCALE_3_4X:
       timing_mid = 8; // 12 * (2.0/3.0);
+      break;
+    case MD_SCALE_1_4X:
+      timing_mid = 48;
+      break;
+    case MD_SCALE_1_8X:
+      timing_mid = 96;
       break;
     }
     return timing_mid;

--- a/avr/cores/megacommand/MCL/MDSeqTrack.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.h
@@ -15,10 +15,10 @@
 //[0 = 1x, 1=2x, 2=3/4x, 3=3/2x]
 
 // MCL Track scale
-#define md_scale_1x 1
-#define md_scale_2x 0
-#define md_scale_3_4x 2
-#define md_scale_3_2x 3
+#define MD_SCALE_1X 1
+#define MD_SCALE_2X 0
+#define MD_SCALE_3_4X 2
+#define MD_SCALE_3_2X 3
 
 // forward declare MDTrack
 class MDTrack;

--- a/avr/cores/megacommand/MCL/MDSeqTrack.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.h
@@ -4,7 +4,7 @@
 #define MDSEQTRACK_H__
 
 #include "MDSeqTrackData.h"
-
+#include "SeqTrack.h"
 #define UART1_PORT 1
 
 #define SEQ_NOTEBUF_SIZE 8
@@ -147,10 +147,10 @@ public:
     case MD_SCALE_2X:
       timing_mid = 6;
       break;
-    case MD_SCALE_3_2X:
+    case MD_SCALE_3_4X:
       timing_mid = 16; // 12 * (4.0/3.0);
       break;
-    case MD_SCALE_3_4X:
+    case MD_SCALE_3_2X:
       timing_mid = 8; // 12 * (2.0/3.0);
       break;
     case MD_SCALE_1_2X:

--- a/avr/cores/megacommand/MCL/MDSeqTrack.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.h
@@ -15,10 +15,10 @@
 //[0 = 1x, 1=2x, 2=3/4x, 3=3/2x]
 
 // MCL Track scale
-#define MD_SCALE_1X 1
-#define MD_SCALE_2X 0
-#define MD_SCALE_3_4X 2
-#define MD_SCALE_3_2X 3
+#define MD_SCALE_1X 64
+#define MD_SCALE_2X 65
+#define MD_SCALE_3_4X 66
+#define MD_SCALE_3_2X 67
 
 // forward declare MDTrack
 class MDTrack;
@@ -61,6 +61,7 @@ public:
     iterations_7 = 1;
     iterations_8 = 1;
     oneshot_mask = 0;
+    mod12_counter = 0;
     mute_until_start = false;
   }
 

--- a/avr/cores/megacommand/MCL/MDSeqTrack.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.h
@@ -114,10 +114,10 @@ public:
     case MD_SCALE_2X:
       timing_mid = 6;
       break;
-    case MD_SCALE_3_4X:
+    case MD_SCALE_3_2X:
       timing_mid = 16; // 12 * (4.0/3.0);
       break;
-    case MD_SCALE_3_2X:
+    case MD_SCALE_3_4X:
       timing_mid = 8; // 12 * (2.0/3.0);
       break;
     }

--- a/avr/cores/megacommand/MCL/MDSeqTrack.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.h
@@ -61,7 +61,7 @@ public:
   void mute() { mute_state = SEQ_MUTE_ON; }
   void unmute() { mute_state = SEQ_MUTE_OFF; }
 
-  ALWAYS_INLINE() void init() {
+  ALWAYS_INLINE() void reset() {
     step_count = 0;
     iterations_5 = 1;
     iterations_6 = 1;

--- a/avr/cores/megacommand/MCL/MDSeqTrack.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.h
@@ -19,6 +19,7 @@ class MDSeqTrack : public MDSeqTrackData {
 public:
   uint8_t track_number;
   uint8_t step_count;
+  uint8_t mod12_counter;
 
   //Conditional counters
   uint8_t iterations_5;

--- a/avr/cores/megacommand/MCL/MDSeqTrack.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.h
@@ -154,7 +154,7 @@ public:
       timing_mid = 8; // 12 * (2.0/3.0);
       break;
     case MD_SCALE_1_2X:
-      timing_mid = 16;
+      timing_mid = 24;
       break;
     case MD_SCALE_1_4X:
       timing_mid = 48;

--- a/avr/cores/megacommand/MCL/MDSeqTrack.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.h
@@ -19,11 +19,13 @@
 #define MD_SCALE_2X 65
 #define MD_SCALE_3_4X 66
 #define MD_SCALE_3_2X 67
-#define MD_SCALE_1_4X 68
-#define MD_SCALE_1_8X 69
+#define MD_SCALE_1_2X 68
+#define MD_SCALE_1_4X 69
+#define MD_SCALE_1_8X 70
 
-const uint8_t md_scales[6] PROGMEM = {MD_SCALE_1X,   MD_SCALE_2X,
+const uint8_t md_scales[7] PROGMEM = {MD_SCALE_1X,   MD_SCALE_2X,
                                       MD_SCALE_3_4X, MD_SCALE_3_2X,
+                                      MD_SCALE_1_2X,
                                       MD_SCALE_1_4X, MD_SCALE_1_8X};
 // forward declare MDTrack
 class MDTrack;
@@ -128,7 +130,8 @@ public:
   void rotate_right();
   void reverse();
 
-  float get_scale_multiplier(uint8_t scale);
+  float get_scale_multiplier(bool inverse = false);
+  float get_scale_multiplier(uint8_t scale, bool inverse = false);
   void set_scale(uint8_t _scale);
 
   void copy_step(uint8_t n, MDSeqStep *step);
@@ -149,6 +152,9 @@ public:
       break;
     case MD_SCALE_3_4X:
       timing_mid = 8; // 12 * (2.0/3.0);
+      break;
+    case MD_SCALE_1_2X:
+      timing_mid = 16;
       break;
     case MD_SCALE_1_4X:
       timing_mid = 48;

--- a/avr/cores/megacommand/MCL/MDSeqTrack.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.h
@@ -11,22 +11,22 @@
 #define SEQ_MUTE_ON 1
 #define SEQ_MUTE_OFF 0
 
-// MD Pattern scale
+// MD Pattern speed
 //[0 = 1x, 1=2x, 2=3/4x, 3=3/2x]
 
-// MCL Track scale
-#define MD_SCALE_1X 64
-#define MD_SCALE_2X 65
-#define MD_SCALE_3_4X 66
-#define MD_SCALE_3_2X 67
-#define MD_SCALE_1_2X 68
-#define MD_SCALE_1_4X 69
-#define MD_SCALE_1_8X 70
+// MCL Track speed
+#define MD_SPEED_1X 64
+#define MD_SPEED_2X 65
+#define MD_SPEED_3_4X 66
+#define MD_SPEED_3_2X 67
+#define MD_SPEED_1_2X 68
+#define MD_SPEED_1_4X 69
+#define MD_SPEED_1_8X 70
 
-const uint8_t md_scales[7] PROGMEM = {MD_SCALE_1X,   MD_SCALE_2X,
-                                      MD_SCALE_3_4X, MD_SCALE_3_2X,
-                                      MD_SCALE_1_2X,
-                                      MD_SCALE_1_4X, MD_SCALE_1_8X};
+const uint8_t md_speeds[7] PROGMEM = {MD_SPEED_1X,   MD_SPEED_2X,
+                                      MD_SPEED_3_4X, MD_SPEED_3_2X,
+                                      MD_SPEED_1_2X,
+                                      MD_SPEED_1_4X, MD_SPEED_1_8X};
 // forward declare MDTrack
 class MDTrack;
 
@@ -130,36 +130,36 @@ public:
   void rotate_right();
   void reverse();
 
-  float get_scale_multiplier(bool inverse = false);
-  float get_scale_multiplier(uint8_t scale, bool inverse = false);
-  void set_scale(uint8_t _scale);
+  float get_speed_multiplier(bool inverse = false);
+  float get_speed_multiplier(uint8_t speed, bool inverse = false);
+  void set_speed(uint8_t _speed);
 
   void copy_step(uint8_t n, MDSeqStep *step);
   void paste_step(uint8_t n, MDSeqStep *step);
 
   ALWAYS_INLINE() uint8_t get_timing_mid() {
     uint8_t timing_mid;
-    switch (scale) {
+    switch (speed) {
     default:
-    case MD_SCALE_1X:
+    case MD_SPEED_1X:
       timing_mid = 12;
       break;
-    case MD_SCALE_2X:
+    case MD_SPEED_2X:
       timing_mid = 6;
       break;
-    case MD_SCALE_3_4X:
+    case MD_SPEED_3_4X:
       timing_mid = 16; // 12 * (4.0/3.0);
       break;
-    case MD_SCALE_3_2X:
+    case MD_SPEED_3_2X:
       timing_mid = 8; // 12 * (2.0/3.0);
       break;
-    case MD_SCALE_1_2X:
+    case MD_SPEED_1_2X:
       timing_mid = 24;
       break;
-    case MD_SCALE_1_4X:
+    case MD_SPEED_1_4X:
       timing_mid = 48;
       break;
-    case MD_SCALE_1_8X:
+    case MD_SPEED_1_8X:
       timing_mid = 96;
       break;
     }

--- a/avr/cores/megacommand/MCL/MDSeqTrack.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.h
@@ -102,6 +102,26 @@ public:
 
   void copy_step(uint8_t n, MDSeqStep *step);
   void paste_step(uint8_t n, MDSeqStep *step);
+
+  ALWAYS_INLINE() uint8_t get_timing_mid() {
+    uint8_t timing_mid;
+    switch (scale) {
+    default:
+    case MD_SCALE_1X:
+      timing_mid = 12;
+      break;
+    case MD_SCALE_2X:
+      timing_mid = 6;
+      break;
+    case MD_SCALE_3_4X:
+      timing_mid = 16; // 12 * (4.0/3.0);
+      break;
+    case MD_SCALE_3_2X:
+      timing_mid = 8; // 12 * (2.0/3.0);
+      break;
+    }
+    return timing_mid;
+  }
 };
 
 #endif /* MDSEQTRACK_H__ */

--- a/avr/cores/megacommand/MCL/MDSeqTrackData.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrackData.h
@@ -19,7 +19,7 @@ public:
 class MDSeqTrackData {
 public:
   uint8_t length;
-  uint8_t scale;
+  uint8_t speed;
   uint8_t reserved[4];
   uint8_t locks[NUM_MD_LOCKS][NUM_MD_STEPS];
   uint8_t locks_params[NUM_MD_LOCKS];
@@ -29,7 +29,7 @@ public:
   uint8_t timing[NUM_MD_STEPS];
   void init() {
   length = 16;
-  scale = 1;
+  speed = 1;
   memset(&locks, 0, NUM_MD_LOCKS * NUM_MD_STEPS);
   memset(&locks_params, 0, NUM_MD_LOCKS);
   pattern_mask = 0;

--- a/avr/cores/megacommand/MCL/MDSeqTrackData.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrackData.h
@@ -19,7 +19,7 @@ public:
 class MDSeqTrackData {
 public:
   uint8_t length;
-  uint8_t speed;
+  uint8_t scale;
   uint8_t reserved[4];
   uint8_t locks[NUM_MD_LOCKS][NUM_MD_STEPS];
   uint8_t locks_params[NUM_MD_LOCKS];
@@ -29,7 +29,7 @@ public:
   uint8_t timing[NUM_MD_STEPS];
   void init() {
   length = 16;
-  resolution = 1;
+  scale = 1;
   memset(&locks, 0, NUM_MD_LOCKS * NUM_MD_STEPS);
   memset(&locks_params, 0, NUM_MD_LOCKS);
   pattern_mask = 0;

--- a/avr/cores/megacommand/MCL/MDSeqTrackData.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrackData.h
@@ -4,6 +4,7 @@
 #define MDSEQTRACKDATA_H__
 
 #define NUM_MD_LOCKS 4
+#define NUM_MD_STEPS 64
 
 class MDSeqStep {
 public:
@@ -18,23 +19,23 @@ public:
 class MDSeqTrackData {
 public:
   uint8_t length;
-  uint8_t resolution;
+  uint8_t speed;
   uint8_t reserved[4];
-  uint8_t locks[NUM_MD_LOCKS][64];
+  uint8_t locks[NUM_MD_LOCKS][NUM_MD_STEPS];
   uint8_t locks_params[NUM_MD_LOCKS];
   uint64_t pattern_mask;
   uint64_t lock_mask;
-  uint8_t conditional[64];
-  uint8_t timing[64];
+  uint8_t conditional[NUM_MD_STEPS];
+  uint8_t timing[NUM_MD_STEPS];
   void init() {
   length = 16;
   resolution = 1;
-  memset(&locks, 0, NUM_MD_LOCKS * 64);
+  memset(&locks, 0, NUM_MD_LOCKS * NUM_MD_STEPS);
   memset(&locks_params, 0, NUM_MD_LOCKS);
   pattern_mask = 0;
   lock_mask = 0;
-  memset(&conditional, 0, 64);
-  memset(&timing, 12, 64);
+  memset(&conditional, 0, NUM_MD_STEPS);
+  memset(&timing, 12, NUM_MD_STEPS);
   }
 };
 

--- a/avr/cores/megacommand/MCL/MDTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDTrack.cpp
@@ -200,7 +200,7 @@ void MDTrack::load_seq_data(int tracknumber) {
     mcl_seq.md_tracks[tracknumber].clear_track();
   } else {
     memcpy(&mcl_seq.md_tracks[tracknumber], &seq_data, sizeof(seq_data));
-    if (mcl_seq.md_tracks[tracknumber].scale < 64) { mcl_seq.md_tracks[tracknumber].scale = MD_SCALE_1X; }
+    if (mcl_seq.md_tracks[tracknumber].scale < MD_SCALE_1X) { mcl_seq.md_tracks[tracknumber].scale = MD_SCALE_1X; }
     mcl_seq.md_tracks[tracknumber].oneshot_mask = 0;
     mcl_seq.md_tracks[tracknumber].set_length(
         mcl_seq.md_tracks[tracknumber].length);

--- a/avr/cores/megacommand/MCL/MDTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDTrack.cpp
@@ -200,6 +200,7 @@ void MDTrack::load_seq_data(int tracknumber) {
     mcl_seq.md_tracks[tracknumber].clear_track();
   } else {
     memcpy(&mcl_seq.md_tracks[tracknumber], &seq_data, sizeof(seq_data));
+    if (mcl_seq.md_tracks[tracknumber].scale < 64) { mcl_seq.md_tracks[tracknumber].scale = MD_SCALE_1X; }
     mcl_seq.md_tracks[tracknumber].oneshot_mask = 0;
     mcl_seq.md_tracks[tracknumber].set_length(
         mcl_seq.md_tracks[tracknumber].length);

--- a/avr/cores/megacommand/MCL/MDTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDTrack.cpp
@@ -201,7 +201,7 @@ void MDTrack::load_seq_data(int tracknumber) {
     mcl_seq.md_tracks[tracknumber].clear_track();
   } else {
     memcpy(&mcl_seq.md_tracks[tracknumber], &seq_data, sizeof(seq_data));
-    if (mcl_seq.md_tracks[tracknumber].scale < MD_SCALE_1X) { mcl_seq.md_tracks[tracknumber].scale = MD_SCALE_1X; }
+    if (mcl_seq.md_tracks[tracknumber].speed < MD_SPEED_1X) { mcl_seq.md_tracks[tracknumber].speed = MD_SPEED_1X; }
     mcl_seq.md_tracks[tracknumber].oneshot_mask = 0;
     mcl_seq.md_tracks[tracknumber].set_length(
         mcl_seq.md_tracks[tracknumber].length);
@@ -375,7 +375,7 @@ bool MDTrack::store_track_in_grid(int32_t column, int32_t row, int track,
       if (merge == SAVE_MD) {
         md_seq_track.init();
         md_seq_track.length = length;
-        md_seq_track.scale = MD_SCALE_1X + kitextra.doubleTempo;
+        md_seq_track.speed = MD_SPEED_1X + kitextra.doubleTempo;
         DEBUG_PRINTLN("SAVE_MD");
       }
       // merge md pattern data with seq_data

--- a/avr/cores/megacommand/MCL/MDTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDTrack.cpp
@@ -374,6 +374,7 @@ bool MDTrack::store_track_in_grid(int32_t column, int32_t row, int track,
       if (merge == SAVE_MD) {
         md_seq_track.init();
         seq_data.length = length;
+        seq_data.scale = MD_SCALE_1X + kitextra.scale;
       }
       // merge md pattern data with seq_data
       md_seq_track.merge_from_md(this);

--- a/avr/cores/megacommand/MCL/MDTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDTrack.cpp
@@ -45,6 +45,7 @@ bool MDTrack::get_track_from_pattern(int tracknumber, uint8_t column) {
   kitextra.patternLength = MD.pattern.patternLength;
   kitextra.doubleTempo = MD.pattern.doubleTempo;
   kitextra.scale = MD.pattern.scale;
+  DEBUG_DUMP(MD.pattern.scale);
 
   kitextra.accentEditAll = MD.pattern.accentEditAll;
   kitextra.slideEditAll = MD.pattern.slideEditAll;
@@ -373,8 +374,9 @@ bool MDTrack::store_track_in_grid(int32_t column, int32_t row, int track,
       }
       if (merge == SAVE_MD) {
         md_seq_track.init();
-        seq_data.length = length;
-        seq_data.scale = MD_SCALE_1X + kitextra.scale;
+        md_seq_track.length = length;
+        md_seq_track.scale = MD_SCALE_1X + kitextra.doubleTempo;
+        DEBUG_PRINTLN("SAVE_MD");
       }
       // merge md pattern data with seq_data
       md_seq_track.merge_from_md(this);
@@ -414,7 +416,7 @@ bool MDTrack::store_track_in_grid(int32_t column, int32_t row, int track,
   uint8_t model = machine.model;
   grid_page.row_headers[grid_page.cur_row].update_model(column, model,
                                                         MD_TRACK_TYPE);
-
+  DEBUG_DUMP(seq_data.length);
   DEBUG_PRINTLN("Track stored in grid");
   DEBUG_PRINT(column);
   DEBUG_PRINT(" ");

--- a/avr/cores/megacommand/MCL/Menu.h
+++ b/avr/cores/megacommand/MCL/Menu.h
@@ -2,7 +2,7 @@
 #define MENU_H__
 
 #define MAX_MENU_ITEMS 16
-#define MAX_MENU_OPTIONS 6
+#define MAX_MENU_OPTIONS 7
 
 typedef void (*FP)();
 

--- a/avr/cores/megacommand/MCL/SeqExtStepPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqExtStepPage.cpp
@@ -11,7 +11,7 @@ void SeqExtStepPage::config() {
 
 #ifdef EXT_TRACKS
 /*
-  if (mcl_seq.ext_tracks[last_ext_track].scale == EXT_SCALE_2X) {
+  if (mcl_seq.ext_tracks[last_ext_track].speed == EXT_SPEED_2X) {
     strcpy(info1, "HI-RES");
   } else {
     strcpy(info1, "LOW-RES");
@@ -225,7 +225,7 @@ void SeqExtStepPage::display() {
   if (mcl_gui.show_encoder_value(&seq_param2) &&
         (note_interface.notes_count_on() > 0) && (!show_seq_menu) &&
         (!show_step_menu)) {
-      mcl_gui.draw_microtiming(get_ext_scale(mcl_seq.ext_tracks[last_ext_track].scale), seq_param2.cur);
+      mcl_gui.draw_microtiming(get_ext_speed(mcl_seq.ext_tracks[last_ext_track].speed), seq_param2.cur);
    }
   oled_display.display();
 #endif

--- a/avr/cores/megacommand/MCL/SeqExtStepPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqExtStepPage.cpp
@@ -10,11 +10,13 @@ void SeqExtStepPage::config() {
   constexpr uint8_t len1 = sizeof(info1);
 
 #ifdef EXT_TRACKS
+/*
   if (mcl_seq.ext_tracks[last_ext_track].scale == EXT_SCALE_2X) {
     strcpy(info1, "HI-RES");
   } else {
     strcpy(info1, "LOW-RES");
   }
+*/
 #endif
 
   strcpy(info2, "EXT");

--- a/avr/cores/megacommand/MCL/SeqExtStepPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqExtStepPage.cpp
@@ -221,8 +221,12 @@ void SeqExtStepPage::display() {
   }
 
   draw_pattern_mask(page_select * 16, DEVICE_A4);
-
   SeqPage::display();
+  if (mcl_gui.show_encoder_value(&seq_param2) &&
+        (note_interface.notes_count_on() > 0) && (!show_seq_menu) &&
+        (!show_step_menu)) {
+      mcl_gui.draw_microtiming(get_ext_scale(mcl_seq.ext_tracks[last_ext_track].scale), seq_param2.cur);
+   }
   oled_display.display();
 #endif
 }

--- a/avr/cores/megacommand/MCL/SeqExtStepPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqExtStepPage.cpp
@@ -10,7 +10,7 @@ void SeqExtStepPage::config() {
   constexpr uint8_t len1 = sizeof(info1);
 
 #ifdef EXT_TRACKS
-  if (mcl_seq.ext_tracks[last_ext_track].resolution == EXT_SCALE_1X) {
+  if (mcl_seq.ext_tracks[last_ext_track].scale == EXT_SCALE_2X) {
     strcpy(info1, "HI-RES");
   } else {
     strcpy(info1, "LOW-RES");
@@ -25,7 +25,7 @@ void SeqExtStepPage::config() {
 
 void SeqExtStepPage::config_encoders() {
 #ifdef EXT_TRACKS
-  if (mcl_seq.ext_tracks[last_ext_track].resolution == EXT_SCALE_1X) {
+  if (mcl_seq.ext_tracks[last_ext_track].scale == EXT_SCALE_2X) {
     seq_param2.cur = 6;
     seq_param2.max = 11;
   } else {
@@ -81,7 +81,7 @@ void SeqExtStepPage::display() {
   // 0  1   2  3  4  5  6  7  8  9  10  11
   //  -5  -4 -3 -2 -1 0
 #ifdef EXT_TRACKS
-  if (mcl_seq.ext_tracks[last_ext_track].resolution == 1) {
+  if (mcl_seq.ext_tracks[last_ext_track].scale == 1) {
     if (seq_param2.getValue() == 0) {
       GUI.put_string_at(2, "--");
     } else if ((seq_param2.getValue() < 6) &&
@@ -142,7 +142,7 @@ void SeqExtStepPage::display() {
     GUI.put_value_at(6, seq_param3.getValue());
 
     GUI.put_value_at(6, (seq_param3.getValue() /
-                         (2 / mcl_seq.ext_tracks[last_ext_track].resolution)));
+                         (2 / mcl_seq.ext_tracks[last_ext_track].scale)));
     if (Analog4.connected) {
       GUI.put_string_at(10, "A4T");
     } else {
@@ -179,7 +179,7 @@ void SeqExtStepPage::display() {
   auto &active_track = mcl_seq.ext_tracks[last_ext_track];
   strcpy(K, "--");
   K[3] = '\0';
-  if (active_track.resolution == 1) {
+  if (active_track.scale == 1) {
     if (seq_param2.getValue() == 0) {
     } else if ((seq_param2.getValue() < 6) &&
                (seq_param2.getValue() != 0)) {
@@ -210,7 +210,7 @@ void SeqExtStepPage::display() {
     }
   }
 
-  itoa(seq_param3.getValue() / (2 / active_track.resolution), K, 10);
+  itoa(seq_param3.getValue() / (2 / active_track.scale), K, 10);
   draw_knob(2, "LEN", K);
 
   if (notes_held > 0) {
@@ -292,7 +292,7 @@ bool SeqExtStepPage::handleEvent(gui_event_t *event) {
         seq_param1.cur = condition;
         // Micro
         if (utiming == 0) {
-          if (active_track.resolution == 1) {
+          if (active_track.scale == EXT_SCALE_2X) {
             utiming = 6;
             seq_param2.max = 11;
           } else {

--- a/avr/cores/megacommand/MCL/SeqExtStepPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqExtStepPage.cpp
@@ -10,7 +10,7 @@ void SeqExtStepPage::config() {
   constexpr uint8_t len1 = sizeof(info1);
 
 #ifdef EXT_TRACKS
-  if (mcl_seq.ext_tracks[last_ext_track].resolution == 1) {
+  if (mcl_seq.ext_tracks[last_ext_track].resolution == EXT_SCALE_1X) {
     strcpy(info1, "HI-RES");
   } else {
     strcpy(info1, "LOW-RES");
@@ -25,7 +25,7 @@ void SeqExtStepPage::config() {
 
 void SeqExtStepPage::config_encoders() {
 #ifdef EXT_TRACKS
-  if (mcl_seq.ext_tracks[last_ext_track].resolution == 1) {
+  if (mcl_seq.ext_tracks[last_ext_track].resolution == EXT_SCALE_1X) {
     seq_param2.cur = 6;
     seq_param2.max = 11;
   } else {

--- a/avr/cores/megacommand/MCL/SeqPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqPage.cpp
@@ -91,6 +91,15 @@ uint8_t SeqPage::get_md_scale(uint8_t scale_id) {
         return scale;
 }
 
+uint8_t SeqPage::get_ext_scale(uint8_t scale_id) {
+        uint8_t scale = 0;
+        for (uint8_t n = 0; n < sizeof(md_scales); n++) {
+           if (pgm_read_byte(&ext_scales[n]) == mcl_seq.ext_tracks[last_ext_track].scale) { scale = n; }
+        }
+        return scale;
+}
+
+
 bool SeqPage::handleEvent(gui_event_t *event) {
   if (note_interface.is_event(event)) {
     uint8_t port = event->port;
@@ -209,7 +218,7 @@ bool SeqPage::handleEvent(gui_event_t *event) {
       } else {
       #ifdef EXT_TRACKS
         opt_trackid = last_ext_track + 1;
-        opt_scale = (mcl_seq.ext_tracks[last_ext_track].scale);
+        opt_scale = get_ext_scale(mcl_seq.ext_tracks[last_ext_track].scale);
       #endif
       }
 
@@ -279,7 +288,7 @@ bool SeqPage::handleEvent(gui_event_t *event) {
       } else {
       #ifdef EXT_TRACKS
         opt_trackid = last_ext_track + 1;
-        opt_scale = (mcl_seq.ext_tracks[last_ext_track].scale);
+        opt_scale = get_ext_scale(mcl_seq.ext_tracks[last_ext_track].scale);
       #endif
       }
       // capture current midi_device value
@@ -603,8 +612,7 @@ void opt_scale_handler() {
   }
 #ifdef EXT_TRACKS
   else {
-    uint8_t ext_scales[4] = { EXT_SCALE_1X, EXT_SCALE_2X, EXT_SCALE_3_4X, EXT_SCALE_3_2X };
-    mcl_seq.ext_tracks[last_ext_track].set_scale(ext_scales[opt_scale]);
+    mcl_seq.ext_tracks[last_ext_track].set_scale(pgm_read_byte(&ext_scales[opt_scale]));
     seq_extstep_page.config_encoders();
   }
 #endif

--- a/avr/cores/megacommand/MCL/SeqPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqPage.cpp
@@ -212,7 +212,6 @@ bool SeqPage::handleEvent(gui_event_t *event) {
       opt_seqpage_capture = this;
 
       if (opt_midi_device_capture == DEVICE_MD) {
-        DEBUG_PRINTLN("okay using MD for length update");
         opt_trackid = last_md_track + 1;
         opt_scale = get_md_scale(mcl_seq.md_tracks[last_md_track].scale);
       } else {

--- a/avr/cores/megacommand/MCL/SeqPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqPage.cpp
@@ -84,10 +84,9 @@ void SeqPage::select_track(uint8_t device, uint8_t track) {
 }
 
 uint8_t SeqPage::get_md_scale(uint8_t scale_id) {
-        uint8_t md_scales[4] = { MD_SCALE_1X, MD_SCALE_2X, MD_SCALE_3_4X, MD_SCALE_3_2X };
         uint8_t scale = 0;
         for (uint8_t n = 0; n < sizeof(md_scales); n++) {
-           if (md_scales[n] == mcl_seq.md_tracks[last_md_track].scale) { scale = n; }
+           if (pgm_read_byte(&md_scales[n]) == mcl_seq.md_tracks[last_md_track].scale) { scale = n; }
         }
         return scale;
 }
@@ -599,8 +598,7 @@ void opt_scale_handler() {
 
   if (opt_midi_device_capture == DEVICE_MD) {
     DEBUG_PRINTLN("okay using MD for length update");
-    uint8_t md_scales[4] = { MD_SCALE_1X, MD_SCALE_2X, MD_SCALE_3_4X, MD_SCALE_3_2X };
-    mcl_seq.md_tracks[last_md_track].set_scale(md_scales[opt_scale]);
+    mcl_seq.md_tracks[last_md_track].set_scale(pgm_read_byte(&md_scales[opt_scale]));
     seq_step_page.config_encoders();
   }
 #ifdef EXT_TRACKS

--- a/avr/cores/megacommand/MCL/SeqPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqPage.cpp
@@ -12,7 +12,7 @@ bool SeqPage::toggle_device = true;
 
 uint8_t SeqPage::step_select = 255;
 
-uint8_t opt_scale = 1;
+uint8_t opt_speed = 1;
 uint8_t opt_trackid = 1;
 uint8_t opt_copy = 0;
 uint8_t opt_paste = 0;
@@ -83,20 +83,20 @@ void SeqPage::select_track(uint8_t device, uint8_t track) {
   GUI.currentPage()->config();
 }
 
-uint8_t SeqPage::get_md_scale(uint8_t scale_id) {
-        uint8_t scale = 0;
-        for (uint8_t n = 0; n < sizeof(md_scales); n++) {
-           if (pgm_read_byte(&md_scales[n]) == mcl_seq.md_tracks[last_md_track].scale) { scale = n; }
+uint8_t SeqPage::get_md_speed(uint8_t speed_id) {
+        uint8_t speed = 0;
+        for (uint8_t n = 0; n < sizeof(md_speeds); n++) {
+           if (pgm_read_byte(&md_speeds[n]) == mcl_seq.md_tracks[last_md_track].speed) { speed = n; }
         }
-        return scale;
+        return speed;
 }
 
-uint8_t SeqPage::get_ext_scale(uint8_t scale_id) {
-        uint8_t scale = 0;
-        for (uint8_t n = 0; n < sizeof(md_scales); n++) {
-           if (pgm_read_byte(&ext_scales[n]) == mcl_seq.ext_tracks[last_ext_track].scale) { scale = n; }
+uint8_t SeqPage::get_ext_speed(uint8_t speed_id) {
+        uint8_t speed = 0;
+        for (uint8_t n = 0; n < sizeof(md_speeds); n++) {
+           if (pgm_read_byte(&ext_speeds[n]) == mcl_seq.ext_tracks[last_ext_track].speed) { speed = n; }
         }
-        return scale;
+        return speed;
 }
 
 
@@ -213,11 +213,11 @@ bool SeqPage::handleEvent(gui_event_t *event) {
 
       if (opt_midi_device_capture == DEVICE_MD) {
         opt_trackid = last_md_track + 1;
-        opt_scale = get_md_scale(mcl_seq.md_tracks[last_md_track].scale);
+        opt_speed = get_md_speed(mcl_seq.md_tracks[last_md_track].speed);
       } else {
       #ifdef EXT_TRACKS
         opt_trackid = last_ext_track + 1;
-        opt_scale = get_ext_scale(mcl_seq.ext_tracks[last_ext_track].scale);
+        opt_speed = get_ext_speed(mcl_seq.ext_tracks[last_ext_track].speed);
       #endif
       }
 
@@ -283,11 +283,11 @@ bool SeqPage::handleEvent(gui_event_t *event) {
         DEBUG_PRINTLN("okay using MD for length update");
         opt_trackid = last_md_track + 1;
 
-        opt_scale = get_md_scale(mcl_seq.md_tracks[last_md_track].scale);
+        opt_speed = get_md_speed(mcl_seq.md_tracks[last_md_track].speed);
       } else {
       #ifdef EXT_TRACKS
         opt_trackid = last_ext_track + 1;
-        opt_scale = get_ext_scale(mcl_seq.ext_tracks[last_ext_track].scale);
+        opt_speed = get_ext_speed(mcl_seq.ext_tracks[last_ext_track].speed);
       #endif
       }
       // capture current midi_device value
@@ -440,14 +440,14 @@ void SeqPage::draw_pattern_mask(uint8_t offset, uint8_t device,
 
       /* uint8_t step_count =
            ((MidiClock.div32th_counter /
-             mcl_seq.ext_tracks[last_ext_track].scale) -
+             mcl_seq.ext_tracks[last_ext_track].speed) -
             (mcl_actions.start_clock32th /
-             mcl_seq.ext_tracks[last_ext_track].scale)) -
+             mcl_seq.ext_tracks[last_ext_track].speed)) -
            (mcl_seq.ext_tracks[last_ext_track].length *
             ((MidiClock.div32th_counter /
-                  mcl_seq.ext_tracks[last_ext_track].scale -
+                  mcl_seq.ext_tracks[last_ext_track].speed -
               (mcl_actions.start_clock32th /
-               mcl_seq.ext_tracks[last_ext_track].scale)) /
+               mcl_seq.ext_tracks[last_ext_track].speed)) /
              (mcl_seq.ext_tracks[last_ext_track].length)));
        */
       uint8_t step_count = mcl_seq.ext_tracks[last_ext_track].step_count;
@@ -602,16 +602,16 @@ void opt_trackid_handler() {
   opt_seqpage_capture->select_track(opt_midi_device_capture, opt_trackid - 1);
 }
 
-void opt_scale_handler() {
+void opt_speed_handler() {
 
   if (opt_midi_device_capture == DEVICE_MD) {
     DEBUG_PRINTLN("okay using MD for length update");
-    mcl_seq.md_tracks[last_md_track].set_scale(pgm_read_byte(&md_scales[opt_scale]));
+    mcl_seq.md_tracks[last_md_track].set_speed(pgm_read_byte(&md_speeds[opt_speed]));
     seq_step_page.config_encoders();
   }
 #ifdef EXT_TRACKS
   else {
-    mcl_seq.ext_tracks[last_ext_track].set_scale(pgm_read_byte(&ext_scales[opt_scale]));
+    mcl_seq.ext_tracks[last_ext_track].set_speed(pgm_read_byte(&ext_speeds[opt_speed]));
     seq_extstep_page.config_encoders();
   }
 #endif

--- a/avr/cores/megacommand/MCL/SeqPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqPage.cpp
@@ -83,6 +83,15 @@ void SeqPage::select_track(uint8_t device, uint8_t track) {
   GUI.currentPage()->config();
 }
 
+uint8_t SeqPage::get_md_scale(uint8_t scale_id) {
+        uint8_t md_scales[4] = { MD_SCALE_1X, MD_SCALE_2X, MD_SCALE_3_4X, MD_SCALE_3_2X };
+        uint8_t scale = 0;
+        for (uint8_t n = 0; n < sizeof(md_scales); n++) {
+           if (md_scales[n] == mcl_seq.md_tracks[last_md_track].scale) { scale = n; }
+        }
+        return scale;
+}
+
 bool SeqPage::handleEvent(gui_event_t *event) {
   if (note_interface.is_event(event)) {
     uint8_t port = event->port;
@@ -197,7 +206,7 @@ bool SeqPage::handleEvent(gui_event_t *event) {
       if (opt_midi_device_capture == DEVICE_MD) {
         DEBUG_PRINTLN("okay using MD for length update");
         opt_trackid = last_md_track + 1;
-        opt_scale = (mcl_seq.md_tracks[last_md_track].scale);
+        opt_scale = get_md_scale(mcl_seq.md_tracks[last_md_track].scale);
       } else {
       #ifdef EXT_TRACKS
         opt_trackid = last_ext_track + 1;
@@ -266,7 +275,8 @@ bool SeqPage::handleEvent(gui_event_t *event) {
       if (opt_midi_device_capture == DEVICE_MD) {
         DEBUG_PRINTLN("okay using MD for length update");
         opt_trackid = last_md_track + 1;
-        opt_scale = (mcl_seq.md_tracks[last_md_track].scale);
+
+        opt_scale = get_md_scale(mcl_seq.md_tracks[last_md_track].scale);
       } else {
       #ifdef EXT_TRACKS
         opt_trackid = last_ext_track + 1;
@@ -589,12 +599,14 @@ void opt_scale_handler() {
 
   if (opt_midi_device_capture == DEVICE_MD) {
     DEBUG_PRINTLN("okay using MD for length update");
-    mcl_seq.md_tracks[last_md_track].set_scale(opt_scale);
+    uint8_t md_scales[4] = { MD_SCALE_1X, MD_SCALE_2X, MD_SCALE_3_4X, MD_SCALE_3_2X };
+    mcl_seq.md_tracks[last_md_track].set_scale(md_scales[opt_scale]);
     seq_step_page.config_encoders();
   }
 #ifdef EXT_TRACKS
   else {
-    mcl_seq.ext_tracks[last_ext_track].set_scale(opt_scale);
+    uint8_t ext_scales[4] = { EXT_SCALE_1X, EXT_SCALE_2X, EXT_SCALE_3_4X, EXT_SCALE_3_2X };
+    mcl_seq.ext_tracks[last_ext_track].set_scale(ext_scales[opt_scale]);
     seq_extstep_page.config_encoders();
   }
 #endif

--- a/avr/cores/megacommand/MCL/SeqPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqPage.cpp
@@ -12,7 +12,7 @@ bool SeqPage::toggle_device = true;
 
 uint8_t SeqPage::step_select = 255;
 
-uint8_t opt_resolution = 1;
+uint8_t opt_scale = 1;
 uint8_t opt_trackid = 1;
 uint8_t opt_copy = 0;
 uint8_t opt_paste = 0;
@@ -197,11 +197,11 @@ bool SeqPage::handleEvent(gui_event_t *event) {
       if (opt_midi_device_capture == DEVICE_MD) {
         DEBUG_PRINTLN("okay using MD for length update");
         opt_trackid = last_md_track + 1;
-        opt_resolution = (mcl_seq.md_tracks[last_md_track].resolution);
+        opt_scale = (mcl_seq.md_tracks[last_md_track].scale);
       } else {
       #ifdef EXT_TRACKS
         opt_trackid = last_ext_track + 1;
-        opt_resolution = (mcl_seq.ext_tracks[last_ext_track].resolution);
+        opt_scale = (mcl_seq.ext_tracks[last_ext_track].scale);
       #endif
       }
 
@@ -266,11 +266,11 @@ bool SeqPage::handleEvent(gui_event_t *event) {
       if (opt_midi_device_capture == DEVICE_MD) {
         DEBUG_PRINTLN("okay using MD for length update");
         opt_trackid = last_md_track + 1;
-        opt_resolution = (mcl_seq.md_tracks[last_md_track].resolution);
+        opt_scale = (mcl_seq.md_tracks[last_md_track].scale);
       } else {
       #ifdef EXT_TRACKS
         opt_trackid = last_ext_track + 1;
-        opt_resolution = (mcl_seq.ext_tracks[last_ext_track].resolution);
+        opt_scale = (mcl_seq.ext_tracks[last_ext_track].scale);
       #endif
       }
       // capture current midi_device value
@@ -423,14 +423,14 @@ void SeqPage::draw_pattern_mask(uint8_t offset, uint8_t device,
 
       /* uint8_t step_count =
            ((MidiClock.div32th_counter /
-             mcl_seq.ext_tracks[last_ext_track].resolution) -
+             mcl_seq.ext_tracks[last_ext_track].scale) -
             (mcl_actions.start_clock32th /
-             mcl_seq.ext_tracks[last_ext_track].resolution)) -
+             mcl_seq.ext_tracks[last_ext_track].scale)) -
            (mcl_seq.ext_tracks[last_ext_track].length *
             ((MidiClock.div32th_counter /
-                  mcl_seq.ext_tracks[last_ext_track].resolution -
+                  mcl_seq.ext_tracks[last_ext_track].scale -
               (mcl_actions.start_clock32th /
-               mcl_seq.ext_tracks[last_ext_track].resolution)) /
+               mcl_seq.ext_tracks[last_ext_track].scale)) /
              (mcl_seq.ext_tracks[last_ext_track].length)));
        */
       uint8_t step_count = mcl_seq.ext_tracks[last_ext_track].step_count;
@@ -585,16 +585,17 @@ void opt_trackid_handler() {
   opt_seqpage_capture->select_track(opt_midi_device_capture, opt_trackid - 1);
 }
 
-void opt_resolution_handler() {
+void opt_scale_handler() {
 
   if (opt_midi_device_capture == DEVICE_MD) {
     DEBUG_PRINTLN("okay using MD for length update");
-    (mcl_seq.md_tracks[last_md_track].resolution) = opt_resolution;
+    (mcl_seq.md_tracks[last_md_track].set_scale(opt_scale);
+     seq_step_page.config_encoders(opt_scale);
   }
 #ifdef EXT_TRACKS
   else {
-    (mcl_seq.ext_tracks[last_ext_track].resolution) = opt_resolution;
-    seq_extstep_page.config_encoders();
+    (mcl_seq.ext_tracks[last_ext_track].set_scale(opt_scale);
+    seq_extstep_page.config_encoders(opt_scale);
   }
 #endif
   opt_seqpage_capture->init();

--- a/avr/cores/megacommand/MCL/SeqPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqPage.cpp
@@ -589,13 +589,13 @@ void opt_scale_handler() {
 
   if (opt_midi_device_capture == DEVICE_MD) {
     DEBUG_PRINTLN("okay using MD for length update");
-    (mcl_seq.md_tracks[last_md_track].set_scale(opt_scale);
-     seq_step_page.config_encoders(opt_scale);
+    mcl_seq.md_tracks[last_md_track].set_scale(opt_scale);
+    seq_step_page.config_encoders();
   }
 #ifdef EXT_TRACKS
   else {
-    (mcl_seq.ext_tracks[last_ext_track].set_scale(opt_scale);
-    seq_extstep_page.config_encoders(opt_scale);
+    mcl_seq.ext_tracks[last_ext_track].set_scale(opt_scale);
+    seq_extstep_page.config_encoders();
   }
 #endif
   opt_seqpage_capture->init();

--- a/avr/cores/megacommand/MCL/SeqPage.h
+++ b/avr/cores/megacommand/MCL/SeqPage.h
@@ -77,6 +77,8 @@ public:
   void draw_page_index(bool show_page_index = true, uint8_t _playing_idx = 255);
   void select_track(uint8_t device, uint8_t track);
 
+  uint8_t get_md_scale(uint8_t scale_id);
+
   virtual bool handleEvent(gui_event_t *event);
   virtual void loop();
   virtual void display();

--- a/avr/cores/megacommand/MCL/SeqPage.h
+++ b/avr/cores/megacommand/MCL/SeqPage.h
@@ -78,6 +78,7 @@ public:
   void select_track(uint8_t device, uint8_t track);
 
   uint8_t get_md_scale(uint8_t scale_id);
+  uint8_t get_ext_scale(uint8_t scale_id);
 
   virtual bool handleEvent(gui_event_t *event);
   virtual void loop();

--- a/avr/cores/megacommand/MCL/SeqPage.h
+++ b/avr/cores/megacommand/MCL/SeqPage.h
@@ -18,7 +18,7 @@ extern void pattern_len_handler(Encoder *enc);
 
 
 extern uint8_t opt_trackid;
-extern uint8_t opt_scale;
+extern uint8_t opt_speed;
 extern uint8_t opt_copy;
 extern uint8_t opt_paste;
 extern uint8_t opt_clear;
@@ -27,7 +27,7 @@ extern uint8_t opt_reverse;
 extern uint8_t opt_clear_step;
 
 extern void opt_trackid_handler();
-extern void opt_scale_handler();
+extern void opt_speed_handler();
 extern void opt_clear_track_handler();
 extern void opt_clear_locks_handler();
 extern void opt_copy_track_handler();
@@ -77,8 +77,8 @@ public:
   void draw_page_index(bool show_page_index = true, uint8_t _playing_idx = 255);
   void select_track(uint8_t device, uint8_t track);
 
-  uint8_t get_md_scale(uint8_t scale_id);
-  uint8_t get_ext_scale(uint8_t scale_id);
+  uint8_t get_md_speed(uint8_t speed_id);
+  uint8_t get_ext_speed(uint8_t speed_id);
 
   virtual bool handleEvent(gui_event_t *event);
   virtual void loop();

--- a/avr/cores/megacommand/MCL/SeqPage.h
+++ b/avr/cores/megacommand/MCL/SeqPage.h
@@ -18,7 +18,7 @@ extern void pattern_len_handler(Encoder *enc);
 
 
 extern uint8_t opt_trackid;
-extern uint8_t opt_resolution;
+extern uint8_t opt_scale;
 extern uint8_t opt_copy;
 extern uint8_t opt_paste;
 extern uint8_t opt_clear;
@@ -27,7 +27,7 @@ extern uint8_t opt_reverse;
 extern uint8_t opt_clear_step;
 
 extern void opt_trackid_handler();
-extern void opt_resolution_handler();
+extern void opt_scale_handler();
 extern void opt_clear_track_handler();
 extern void opt_clear_locks_handler();
 extern void opt_copy_track_handler();

--- a/avr/cores/megacommand/MCL/SeqPages.cpp
+++ b/avr/cores/megacommand/MCL/SeqPages.cpp
@@ -11,7 +11,7 @@ MCLEncoder seq_lock2(0, 127, ENCODER_RES_PARAM);
 MCLEncoder ptc_param_oct(0, 8, ENCODER_RES_SEQ);
 MCLEncoder ptc_param_finetune(0, 64, ENCODER_RES_SEQ);
 MCLEncoder ptc_param_len(0, 64, ENCODER_RES_SEQ);
-MCLEncoder ptc_param_scale(0, 23, ENCODER_RES_SEQ);
+MCLEncoder ptc_param_speed(0, 23, ENCODER_RES_SEQ);
 
 SeqParamPage seq_param_page[NUM_PARAM_PAGES];
 SeqStepPage seq_step_page(&seq_param1, &seq_param2, &seq_param3, &seq_param4);
@@ -24,7 +24,7 @@ SeqExtStepPage seq_extstep_page(&seq_param1, &seq_param2, &seq_param3,
                                 &seq_param4);
 #endif
 
-SeqPtcPage seq_ptc_page(&ptc_param_oct, &ptc_param_finetune, &ptc_param_len, &ptc_param_scale);
+SeqPtcPage seq_ptc_page(&ptc_param_oct, &ptc_param_finetune, &ptc_param_len, &ptc_param_speed);
 
 ArpPage arp_page(&arp_und, &arp_mode, &arp_speed, &arp_oct);
 
@@ -38,7 +38,7 @@ const menu_t<10> seq_menu_layout PROGMEM = {
         {"CLEAR:", 0, 3, 3, (uint8_t *)&opt_clear, (Page *)NULL, opt_clear_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"}}},
         {"CLEAR:", 0, 3, 3, (uint8_t *)&opt_clear, (Page *)NULL, opt_clear_locks_handler, { {0, "--",}, {1, "LCKS"}, {2, "ALL"}}},
         {"PASTE:", 0, 3, 3, (uint8_t *)&opt_paste, (Page *)NULL, opt_paste_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"}}},
-        {"SCALE:", 0, 7, 7, (uint8_t *)&opt_scale, (Page *)NULL, opt_scale_handler, { {SEQ_SCALE_1X, "1x"}, {SEQ_SCALE_2X , "2x"}, {SEQ_SCALE_3_2X, "3/2x"}, {SEQ_SCALE_3_4X,"3/4x"}, { SEQ_SCALE_1_2X, "1/2x"}, {SEQ_SCALE_1_4X, "1/4x"}, {SEQ_SCALE_1_8X, "1/8x"}}},
+        {"SPEED:", 0, 7, 7, (uint8_t *)&opt_speed, (Page *)NULL, opt_speed_handler, { {SEQ_SPEED_1X, "1x"}, {SEQ_SPEED_2X , "2x"}, {SEQ_SPEED_3_2X, "3/2x"}, {SEQ_SPEED_3_4X,"3/4x"}, { SEQ_SPEED_1_2X, "1/2x"}, {SEQ_SPEED_1_4X, "1/4x"}, {SEQ_SPEED_1_8X, "1/8x"}}},
         {"SHIFT:", 0, 5, 5, (uint8_t *)&opt_shift, (Page *)NULL, opt_shift_track_handler, { {0, "--",}, {1, "L"}, {2, "R"}, {3,"L>ALL"}, {4, "R>ALL"}}},
         {"REVERSE:", 0, 3, 3, (uint8_t *)&opt_reverse, (Page *)NULL, opt_reverse_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"} }},
     },

--- a/avr/cores/megacommand/MCL/SeqPages.cpp
+++ b/avr/cores/megacommand/MCL/SeqPages.cpp
@@ -38,7 +38,7 @@ const menu_t<10> seq_menu_layout PROGMEM = {
         {"CLEAR:", 0, 3, 3, (uint8_t *)&opt_clear, (Page *)NULL, opt_clear_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"}}},
         {"CLEAR:", 0, 3, 3, (uint8_t *)&opt_clear, (Page *)NULL, opt_clear_locks_handler, { {0, "--",}, {1, "LCKS"}, {2, "ALL"}}},
         {"PASTE:", 0, 3, 3, (uint8_t *)&opt_paste, (Page *)NULL, opt_paste_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"}}},
-        {"SCALE:", MD_SCALE_1X, MD_SCALE_3_4X, 4, (uint8_t *)&opt_scale, (Page *)NULL, opt_scale_handler, { {MD_SCALE_1X, "1x"}, {MD_SCALE_2X, "2x"}, {MD_SCALE_3_2X, "3/2x"}, {MD_SCALE_3_4X, "3/4x"} }},
+        {"SCALE:", 0, 4, 4, (uint8_t *)&opt_scale, (Page *)NULL, opt_scale_handler, { {0, "1x"}, {1, "2x"}, {2, "3/2x"}, {3, "3/4x"} }},
         {"SHIFT:", 0, 5, 5, (uint8_t *)&opt_shift, (Page *)NULL, opt_shift_track_handler, { {0, "--",}, {1, "L"}, {2, "R"}, {3,"L>ALL"}, {4, "R>ALL"}}},
         {"REVERSE:", 0, 3, 3, (uint8_t *)&opt_reverse, (Page *)NULL, opt_reverse_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"} }},
     },

--- a/avr/cores/megacommand/MCL/SeqPages.cpp
+++ b/avr/cores/megacommand/MCL/SeqPages.cpp
@@ -11,7 +11,7 @@ MCLEncoder seq_lock2(0, 127, ENCODER_RES_PARAM);
 MCLEncoder ptc_param_oct(0, 8, ENCODER_RES_SEQ);
 MCLEncoder ptc_param_finetune(0, 64, ENCODER_RES_SEQ);
 MCLEncoder ptc_param_len(0, 64, ENCODER_RES_SEQ);
-MCLEncoder ptc_param_speed(0, 23, ENCODER_RES_SEQ);
+MCLEncoder ptc_param_scale(0, 23, ENCODER_RES_SEQ);
 
 SeqParamPage seq_param_page[NUM_PARAM_PAGES];
 SeqStepPage seq_step_page(&seq_param1, &seq_param2, &seq_param3, &seq_param4);
@@ -24,7 +24,7 @@ SeqExtStepPage seq_extstep_page(&seq_param1, &seq_param2, &seq_param3,
                                 &seq_param4);
 #endif
 
-SeqPtcPage seq_ptc_page(&ptc_param_oct, &ptc_param_finetune, &ptc_param_len, &ptc_param_speed);
+SeqPtcPage seq_ptc_page(&ptc_param_oct, &ptc_param_finetune, &ptc_param_len, &ptc_param_scale);
 
 ArpPage arp_page(&arp_und, &arp_mode, &arp_speed, &arp_oct);
 

--- a/avr/cores/megacommand/MCL/SeqPages.cpp
+++ b/avr/cores/megacommand/MCL/SeqPages.cpp
@@ -38,7 +38,7 @@ const menu_t<10> seq_menu_layout PROGMEM = {
         {"CLEAR:", 0, 3, 3, (uint8_t *)&opt_clear, (Page *)NULL, opt_clear_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"}}},
         {"CLEAR:", 0, 3, 3, (uint8_t *)&opt_clear, (Page *)NULL, opt_clear_locks_handler, { {0, "--",}, {1, "LCKS"}, {2, "ALL"}}},
         {"PASTE:", 0, 3, 3, (uint8_t *)&opt_paste, (Page *)NULL, opt_paste_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"}}},
-        {"SCALE:", 0, 7, 7, (uint8_t *)&opt_scale, (Page *)NULL, opt_scale_handler, { {0, "1x"}, {1, "2x"}, {2, "3/2x"}, {3, "3/4x"}, {4, "1/2x"}, {5, "1/4x"}, {6, "1/8x"}}},
+        {"SCALE:", 0, 7, 7, (uint8_t *)&opt_scale, (Page *)NULL, opt_scale_handler, { {SEQ_SCALE_1X, "1x"}, {SEQ_SCALE_2X , "2x"}, {SEQ_SCALE_3_2X, "3/2x"}, {SEQ_SCALE_3_4X,"3/4x"}, { SEQ_SCALE_1_2X, "1/2x"}, {SEQ_SCALE_1_4X, "1/4x"}, {SEQ_SCALE_1_8X, "1/8x"}}},
         {"SHIFT:", 0, 5, 5, (uint8_t *)&opt_shift, (Page *)NULL, opt_shift_track_handler, { {0, "--",}, {1, "L"}, {2, "R"}, {3,"L>ALL"}, {4, "R>ALL"}}},
         {"REVERSE:", 0, 3, 3, (uint8_t *)&opt_reverse, (Page *)NULL, opt_reverse_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"} }},
     },

--- a/avr/cores/megacommand/MCL/SeqPages.cpp
+++ b/avr/cores/megacommand/MCL/SeqPages.cpp
@@ -38,7 +38,7 @@ const menu_t<10> seq_menu_layout PROGMEM = {
         {"CLEAR:", 0, 3, 3, (uint8_t *)&opt_clear, (Page *)NULL, opt_clear_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"}}},
         {"CLEAR:", 0, 3, 3, (uint8_t *)&opt_clear, (Page *)NULL, opt_clear_locks_handler, { {0, "--",}, {1, "LCKS"}, {2, "ALL"}}},
         {"PASTE:", 0, 3, 3, (uint8_t *)&opt_paste, (Page *)NULL, opt_paste_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"}}},
-        {"TRACK RES:", 1, 3, 2, (uint8_t *)&opt_resolution, (Page *)NULL, opt_resolution_handler, { {1, "2x"}, {2, "1x"} }},
+        {"SCALE:", 0, 4, 4, (uint8_t *)&opt_scale, (Page *)NULL, opt_scale_handler, { {1, "1x"}, {0, "2x"}, {2, "3/2x"}, {3, "4/3x"} }},
         {"SHIFT:", 0, 5, 5, (uint8_t *)&opt_shift, (Page *)NULL, opt_shift_track_handler, { {0, "--",}, {1, "L"}, {2, "R"}, {3,"L>ALL"}, {4, "R>ALL"}}},
         {"REVERSE:", 0, 3, 3, (uint8_t *)&opt_reverse, (Page *)NULL, opt_reverse_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"} }},
     },

--- a/avr/cores/megacommand/MCL/SeqPages.cpp
+++ b/avr/cores/megacommand/MCL/SeqPages.cpp
@@ -38,7 +38,7 @@ const menu_t<10> seq_menu_layout PROGMEM = {
         {"CLEAR:", 0, 3, 3, (uint8_t *)&opt_clear, (Page *)NULL, opt_clear_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"}}},
         {"CLEAR:", 0, 3, 3, (uint8_t *)&opt_clear, (Page *)NULL, opt_clear_locks_handler, { {0, "--",}, {1, "LCKS"}, {2, "ALL"}}},
         {"PASTE:", 0, 3, 3, (uint8_t *)&opt_paste, (Page *)NULL, opt_paste_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"}}},
-        {"SCALE:", 0, 4, 4, (uint8_t *)&opt_scale, (Page *)NULL, opt_scale_handler, { {0, "1x"}, {1, "2x"}, {2, "3/2x"}, {3, "3/4x"} }},
+        {"SCALE:", 0, 6, 6, (uint8_t *)&opt_scale, (Page *)NULL, opt_scale_handler, { {0, "1x"}, {1, "2x"}, {2, "3/2x"}, {3, "3/4x"}, {4, "1/4x"}, {5, "1/8x"}}},
         {"SHIFT:", 0, 5, 5, (uint8_t *)&opt_shift, (Page *)NULL, opt_shift_track_handler, { {0, "--",}, {1, "L"}, {2, "R"}, {3,"L>ALL"}, {4, "R>ALL"}}},
         {"REVERSE:", 0, 3, 3, (uint8_t *)&opt_reverse, (Page *)NULL, opt_reverse_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"} }},
     },

--- a/avr/cores/megacommand/MCL/SeqPages.cpp
+++ b/avr/cores/megacommand/MCL/SeqPages.cpp
@@ -38,7 +38,7 @@ const menu_t<10> seq_menu_layout PROGMEM = {
         {"CLEAR:", 0, 3, 3, (uint8_t *)&opt_clear, (Page *)NULL, opt_clear_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"}}},
         {"CLEAR:", 0, 3, 3, (uint8_t *)&opt_clear, (Page *)NULL, opt_clear_locks_handler, { {0, "--",}, {1, "LCKS"}, {2, "ALL"}}},
         {"PASTE:", 0, 3, 3, (uint8_t *)&opt_paste, (Page *)NULL, opt_paste_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"}}},
-        {"SCALE:", 0, 6, 6, (uint8_t *)&opt_scale, (Page *)NULL, opt_scale_handler, { {0, "1x"}, {1, "2x"}, {2, "3/2x"}, {3, "3/4x"}, {4, "1/4x"}, {5, "1/8x"}}},
+        {"SCALE:", 0, 7, 7, (uint8_t *)&opt_scale, (Page *)NULL, opt_scale_handler, { {0, "1x"}, {1, "2x"}, {2, "3/2x"}, {3, "3/4x"}, {4, "1/2x"}, {5, "1/4x"}, {6, "1/8x"}}},
         {"SHIFT:", 0, 5, 5, (uint8_t *)&opt_shift, (Page *)NULL, opt_shift_track_handler, { {0, "--",}, {1, "L"}, {2, "R"}, {3,"L>ALL"}, {4, "R>ALL"}}},
         {"REVERSE:", 0, 3, 3, (uint8_t *)&opt_reverse, (Page *)NULL, opt_reverse_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"} }},
     },

--- a/avr/cores/megacommand/MCL/SeqPages.cpp
+++ b/avr/cores/megacommand/MCL/SeqPages.cpp
@@ -38,7 +38,7 @@ const menu_t<10> seq_menu_layout PROGMEM = {
         {"CLEAR:", 0, 3, 3, (uint8_t *)&opt_clear, (Page *)NULL, opt_clear_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"}}},
         {"CLEAR:", 0, 3, 3, (uint8_t *)&opt_clear, (Page *)NULL, opt_clear_locks_handler, { {0, "--",}, {1, "LCKS"}, {2, "ALL"}}},
         {"PASTE:", 0, 3, 3, (uint8_t *)&opt_paste, (Page *)NULL, opt_paste_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"}}},
-        {"SCALE:", 0, 4, 4, (uint8_t *)&opt_scale, (Page *)NULL, opt_scale_handler, { {1, "1x"}, {0, "2x"}, {2, "3/2x"}, {3, "4/3x"} }},
+        {"SCALE:", MD_SCALE_1X, MD_SCALE_3_4X, 4, (uint8_t *)&opt_scale, (Page *)NULL, opt_scale_handler, { {MD_SCALE_1X, "1x"}, {MD_SCALE_2X, "2x"}, {MD_SCALE_3_2X, "3/2x"}, {MD_SCALE_3_4X, "3/4x"} }},
         {"SHIFT:", 0, 5, 5, (uint8_t *)&opt_shift, (Page *)NULL, opt_shift_track_handler, { {0, "--",}, {1, "L"}, {2, "R"}, {3,"L>ALL"}, {4, "R>ALL"}}},
         {"REVERSE:", 0, 3, 3, (uint8_t *)&opt_reverse, (Page *)NULL, opt_reverse_track_handler, { {0, "--",}, {1, "TRK"}, {2, "ALL"} }},
     },

--- a/avr/cores/megacommand/MCL/SeqPtcPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqPtcPage.cpp
@@ -250,7 +250,7 @@ void SeqPtcPage::display() {
 #ifdef EXT_TRACKS
   else {
     GUI.put_value_at(5, (ptc_param_len.getValue() /
-                         (2 / mcl_seq.ext_tracks[last_ext_track].resolution)));
+                         (2 / mcl_seq.ext_tracks[last_ext_track].scale)));
     if (Analog4.connected) {
       GUI.put_string_at(9, "A4T");
     } else {
@@ -330,7 +330,7 @@ void SeqPtcPage::display() {
 #ifdef EXT_TRACKS
   else {
     itoa(ptc_param_len.getValue() /
-             (2 / mcl_seq.ext_tracks[last_ext_track].resolution),
+             (2 / mcl_seq.ext_tracks[last_ext_track].scale),
          buf1, 10);
     draw_knob(2, "LEN", buf1);
   }

--- a/avr/cores/megacommand/MCL/SeqPtcPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqPtcPage.cpp
@@ -249,8 +249,7 @@ void SeqPtcPage::display() {
   }
 #ifdef EXT_TRACKS
   else {
-    GUI.put_value_at(5, (ptc_param_len.getValue() /
-                         (2 / mcl_seq.ext_tracks[last_ext_track].scale)));
+    GUI.put_value_at(5, (ptc_param_len.getValue()));
     if (Analog4.connected) {
       GUI.put_string_at(9, "A4T");
     } else {
@@ -329,9 +328,7 @@ void SeqPtcPage::display() {
   }
 #ifdef EXT_TRACKS
   else {
-    itoa(ptc_param_len.getValue() /
-             (2 / mcl_seq.ext_tracks[last_ext_track].scale),
-         buf1, 10);
+    itoa(ptc_param_len.getValue(),buf1, 10);
     draw_knob(2, "LEN", buf1);
   }
 #endif

--- a/avr/cores/megacommand/MCL/SeqStepPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqStepPage.cpp
@@ -203,7 +203,7 @@ void SeqStepPage::display() {
         (note_interface.notes_count_on() > 0) && (!show_seq_menu) &&
         (!show_step_menu)) {
 
-      mcl_gui.draw_microtiming(get_md_scale(mcl_seq.md_tracks[last_md_track].scale), seq_param2.cur);
+      mcl_gui.draw_microtiming(get_md_speed(mcl_seq.md_tracks[last_md_track].speed), seq_param2.cur);
     }
   }
   oled_display.display();

--- a/avr/cores/megacommand/MCL/SeqStepPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqStepPage.cpp
@@ -139,7 +139,6 @@ void SeqStepPage::display() {
   char K[4];
 
   uint8_t timing_mid = mcl_seq.md_tracks[last_md_track].get_timing_mid();
-
   if (seq_param1.getValue() == 0) {
     strcpy(K, "L1");
   } else if (seq_param1.getValue() <= 8) {
@@ -204,7 +203,7 @@ void SeqStepPage::display() {
         (note_interface.notes_count_on() > 0) && (!show_seq_menu) &&
         (!show_step_menu)) {
 
-      mcl_gui.draw_microtiming(mcl_seq.md_tracks[last_md_track].scale, seq_param2.cur);
+      mcl_gui.draw_microtiming(get_md_scale(mcl_seq.md_tracks[last_md_track].scale), seq_param2.cur);
     }
   }
   oled_display.display();
@@ -288,7 +287,7 @@ bool SeqStepPage::handleEvent(gui_event_t *event) {
         return true;
       }
 
-      seq_param2.max = 23;
+      seq_param2.max = mcl_seq.md_tracks[last_md_track].get_timing_mid() * 2 - 1;
       int8_t utiming = active_track.timing[step];         // upper
       uint8_t condition = active_track.conditional[step]; // lower
       uint8_t pitch = active_track.get_track_lock(step, 0) - 1;

--- a/avr/cores/megacommand/MCL/SeqStepPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqStepPage.cpp
@@ -96,16 +96,16 @@ void SeqStepPage::display() {
   else if (seq_param1.getValue() == 14) {
     GUI.put_string_at(0, "1S");
   }
-
+  uint8_t timing_mid = mcl_seq.md_tracks[last_md_track].get_timing_mid();
   if (seq_param2.getValue() == 0) {
     GUI.put_string_at(2, "--");
   } else if ((seq_param2.getValue() < 12) && (seq_param2.getValue() != 0)) {
     GUI.put_string_at(2, "-");
-    GUI.put_value_at2(3, 12 - seq_param2.getValue());
+    GUI.put_value_at2(3, timing_mid - seq_param2.getValue());
 
   } else {
     GUI.put_string_at(2, "+");
-    GUI.put_value_at2(3, seq_param2.getValue() - 12);
+    GUI.put_value_at2(3, seq_param2.getValue() - timing_mid);
   }
 
   if (show_pitch) {
@@ -138,8 +138,10 @@ void SeqStepPage::display() {
   oled_display.clearDisplay();
   auto *oldfont = oled_display.getFont();
   draw_knob_frame();
-
   char K[4];
+
+  uint8_t timing_mid = mcl_seq.md_tracks[last_md_track].get_timing_mid();
+
   if (seq_param1.getValue() == 0) {
     strcpy(K, "L1");
   } else if (seq_param1.getValue() <= 8) {
@@ -156,12 +158,13 @@ void SeqStepPage::display() {
 
   strcpy(K, "--");
   K[3] = '\0';
+
   if (seq_param2.getValue() == 0) {
   } else if ((seq_param2.getValue() < 12) && (seq_param2.getValue() != 0)) {
-    itoa(12 - seq_param2.getValue(), K + 1, 10);
+    itoa(timing_mid - seq_param2.getValue(), K + 1, 10);
   } else {
     K[0] = '+';
-    itoa(seq_param2.getValue() - 12, K + 1, 10);
+    itoa(seq_param2.getValue() - timing_mid, K + 1, 10);
   }
   draw_knob(1, "UTIM", K);
 
@@ -314,7 +317,7 @@ bool SeqStepPage::handleEvent(gui_event_t *event) {
       }
       // Micro
       if (utiming == 0) {
-        utiming = 12;
+        utiming = mcl_seq.md_tracks[last_md_track].get_timing_mid();
       }
       seq_param2.cur = utiming;
       seq_param2.old = utiming;
@@ -387,7 +390,7 @@ bool SeqStepPage::handleEvent(gui_event_t *event) {
         if (clock_diff(note_interface.note_hold, slowclock) < TRIG_HOLD_TIME) {
           CLEAR_BIT64(active_track.pattern_mask, step);
           active_track.conditional[step] = 0;
-          active_track.timing[step] = 12; // upper
+          active_track.timing[step] = active_track.get_timing_mid(); // upper
         }
       }
       // Cond

--- a/avr/cores/megacommand/MCL/SeqStepPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqStepPage.cpp
@@ -29,8 +29,15 @@ void SeqStepPage::config() {
   strncat(info1, buf, len1);
   strcpy(info2, "STEP");
 
+  config_encoders();
   // config menu
   config_as_trackedit();
+}
+
+void SeqStepPage::config_encoders() {
+  uint8_t timing_mid = mcl_seq.md_tracks[last_md_track].get_timing_mid();
+  seq_param2.cur = timing_mid;
+  seq_param2.max = timing_mid * 2 - 1;
 }
 
 void SeqStepPage::init() {
@@ -196,7 +203,7 @@ void SeqStepPage::display() {
         (note_interface.notes_count_on() > 0) && (!show_seq_menu) &&
         (!show_step_menu)) {
 
-      mcl_gui.draw_microtiming(mcl_seq.md_tracks[last_md_track].resolution,
+      mcl_gui.draw_microtiming(mcl_seq.md_tracks[last_md_track].scale,
                                seq_param2.cur);
     }
   }

--- a/avr/cores/megacommand/MCL/SeqStepPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqStepPage.cpp
@@ -48,9 +48,7 @@ void SeqStepPage::init() {
   SeqPage::midi_device = midi_active_peering.get_device(UART1_PORT);
 
   seq_param1.max = 14;
-  seq_param2.max = 23;
   seq_param2.min = 1;
-  seq_param2.cur = 12;
   seq_param2.old = 12;
   seq_param1.cur = 0;
   seq_param3.max = 64;
@@ -99,7 +97,7 @@ void SeqStepPage::display() {
   uint8_t timing_mid = mcl_seq.md_tracks[last_md_track].get_timing_mid();
   if (seq_param2.getValue() == 0) {
     GUI.put_string_at(2, "--");
-  } else if ((seq_param2.getValue() < 12) && (seq_param2.getValue() != 0)) {
+  } else if ((seq_param2.getValue() < timing_mid) && (seq_param2.getValue() != 0)) {
     GUI.put_string_at(2, "-");
     GUI.put_value_at2(3, timing_mid - seq_param2.getValue());
 
@@ -160,7 +158,7 @@ void SeqStepPage::display() {
   K[3] = '\0';
 
   if (seq_param2.getValue() == 0) {
-  } else if ((seq_param2.getValue() < 12) && (seq_param2.getValue() != 0)) {
+  } else if ((seq_param2.getValue() < timing_mid) && (seq_param2.getValue() != 0)) {
     itoa(timing_mid - seq_param2.getValue(), K + 1, 10);
   } else {
     K[0] = '+';

--- a/avr/cores/megacommand/MCL/SeqStepPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqStepPage.cpp
@@ -204,8 +204,7 @@ void SeqStepPage::display() {
         (note_interface.notes_count_on() > 0) && (!show_seq_menu) &&
         (!show_step_menu)) {
 
-      mcl_gui.draw_microtiming(mcl_seq.md_tracks[last_md_track].scale,
-                               seq_param2.cur);
+      mcl_gui.draw_microtiming(mcl_seq.md_tracks[last_md_track].scale, seq_param2.cur);
     }
   }
   oled_display.display();

--- a/avr/cores/megacommand/MCL/SeqStepPage.h
+++ b/avr/cores/megacommand/MCL/SeqStepPage.h
@@ -29,6 +29,7 @@ public:
   virtual void setup();
   virtual void init();
   virtual void config();
+  virtual void config_encoders();
   virtual void loop();
   virtual void cleanup();
 };

--- a/avr/cores/megacommand/MCL/SeqTrack.h
+++ b/avr/cores/megacommand/MCL/SeqTrack.h
@@ -37,7 +37,7 @@ public:
       timing_mid = 8; // 12 * (2.0/3.0);
       break;
     case SEQ_SCALE_1_2X:
-      timing_mid = 16;
+      timing_mid = 24;
       break;
     case SEQ_SCALE_1_4X:
       timing_mid = 48;

--- a/avr/cores/megacommand/MCL/SeqTrack.h
+++ b/avr/cores/megacommand/MCL/SeqTrack.h
@@ -3,15 +3,51 @@
 #ifndef SEQTRACK_H__
 #define SEQTRACK_H__
 
+#include "MidiUartParent.hh"
+#include "WProgram.h"
+
+#define SEQ_MUTE_ON 1
+#define SEQ_MUTE_OFF 0
+
+#define SEQ_SCALE_1X 0
+#define SEQ_SCALE_2X 1
+#define SEQ_SCALE_3_4X 2
+#define SEQ_SCALE_3_2X 3
+#define SEQ_SCALE_1_2X 4
+#define SEQ_SCALE_1_4X 5
+#define SEQ_SCALE_1_8X 6
+
 class SeqTrack {
 
 public:
-  uint8_t track_type;
-  uint8_t PatternLengths;
-
-  SeqTrack(Encoder *e1 = NULL,
-               Encoder *e2 = NULL, Encoder *e3 = NULL, Encoder *e4 = NULL) {}
-  void setup();
+  ALWAYS_INLINE() virtual uint8_t get_timing_mid(uint8_t scale) {
+    uint8_t timing_mid;
+    switch (scale) {
+    default:
+    case SEQ_SCALE_1X:
+      timing_mid = 12;
+      break;
+    case SEQ_SCALE_2X:
+      timing_mid = 6;
+      break;
+    case SEQ_SCALE_3_4X:
+      timing_mid = 16; // 12 * (4.0/3.0);
+      break;
+    case SEQ_SCALE_3_2X:
+      timing_mid = 8; // 12 * (2.0/3.0);
+      break;
+    case SEQ_SCALE_1_2X:
+      timing_mid = 16;
+      break;
+    case SEQ_SCALE_1_4X:
+      timing_mid = 48;
+      break;
+    case SEQ_SCALE_1_8X:
+      timing_mid = 96;
+      break;
+    }
+    return timing_mid;
+  }
 };
 
 #endif /* SEQTRACK_H__ */

--- a/avr/cores/megacommand/MCL/SeqTrack.h
+++ b/avr/cores/megacommand/MCL/SeqTrack.h
@@ -9,40 +9,40 @@
 #define SEQ_MUTE_ON 1
 #define SEQ_MUTE_OFF 0
 
-#define SEQ_SCALE_1X 0
-#define SEQ_SCALE_2X 1
-#define SEQ_SCALE_3_4X 2
-#define SEQ_SCALE_3_2X 3
-#define SEQ_SCALE_1_2X 4
-#define SEQ_SCALE_1_4X 5
-#define SEQ_SCALE_1_8X 6
+#define SEQ_SPEED_1X 0
+#define SEQ_SPEED_2X 1
+#define SEQ_SPEED_3_4X 2
+#define SEQ_SPEED_3_2X 3
+#define SEQ_SPEED_1_2X 4
+#define SEQ_SPEED_1_4X 5
+#define SEQ_SPEED_1_8X 6
 
 class SeqTrack {
 
 public:
-  ALWAYS_INLINE() virtual uint8_t get_timing_mid(uint8_t scale) {
+  ALWAYS_INLINE() virtual uint8_t get_timing_mid(uint8_t speed) {
     uint8_t timing_mid;
-    switch (scale) {
+    switch (speed) {
     default:
-    case SEQ_SCALE_1X:
+    case SEQ_SPEED_1X:
       timing_mid = 12;
       break;
-    case SEQ_SCALE_2X:
+    case SEQ_SPEED_2X:
       timing_mid = 6;
       break;
-    case SEQ_SCALE_3_4X:
+    case SEQ_SPEED_3_4X:
       timing_mid = 16; // 12 * (4.0/3.0);
       break;
-    case SEQ_SCALE_3_2X:
+    case SEQ_SPEED_3_2X:
       timing_mid = 8; // 12 * (2.0/3.0);
       break;
-    case SEQ_SCALE_1_2X:
+    case SEQ_SPEED_1_2X:
       timing_mid = 24;
       break;
-    case SEQ_SCALE_1_4X:
+    case SEQ_SPEED_1_4X:
       timing_mid = 48;
       break;
-    case SEQ_SCALE_1_8X:
+    case SEQ_SPEED_1_8X:
       timing_mid = 96;
       break;
     }


### PR DESCRIPTION
Started adding support for track speed multipliers:

1x
2x
3/4x
2/3x
1/2x
1/4x
1/8x

These are now working for the MD.

However following needs doing:

- [x] Fix uTiming page for various scale modes. Timing is scaled according.
- [x] Fix chain mode for scale modes. Ie next_transition[] 
- [x] Add this scale support to A4/Ext tracks
- [x] Fix live record - [ ] Needs test
- [ ] Arpeggiator should be able to work with track scale. ie triplets.
- [x] Fix and test MD Merge (make sure correct scale is imported)
- [ ] Add ability to change scale of all tracks, move to pop up menu ?