### PR TITLE
Transitions for 3/4 and 3/2 track speeds.

### DIFF
--- a/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
@@ -61,8 +61,9 @@ void ExtSeqTrack::seq() {
   if (mute_until_start) {
 
     if (clock_diff(MidiClock.div16th_counter, start_step) == 0) {
-      if (start_step_offset > 0) { start_step_offset--; }
-      else { reset(); }
+      if (MidiClock.mod12_counter == start_step_offset) {
+        reset();
+      }
     }
   }
   uint8_t timing_mid = get_timing_mid();

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.cpp
@@ -61,7 +61,8 @@ void ExtSeqTrack::seq() {
   if (mute_until_start) {
 
     if (clock_diff(MidiClock.div16th_counter, start_step) == 0) {
-      reset();
+      if (start_step_offset > 0) { start_step_offset--; }
+      else { reset(); }
     }
   }
   uint8_t timing_mid = get_timing_mid();

--- a/avr/cores/megacommand/MCL/ExtSeqTrack.h
+++ b/avr/cores/megacommand/MCL/ExtSeqTrack.h
@@ -55,6 +55,7 @@ public:
   uint8_t step_count;
   uint8_t mod12_counter;
   uint32_t start_step;
+  uint8_t start_step_offset;
   bool mute_until_start = false;
 
   // Conditional counters

--- a/avr/cores/megacommand/MCL/GridTask.cpp
+++ b/avr/cores/megacommand/MCL/GridTask.cpp
@@ -38,13 +38,14 @@ void GridTask::run() {
     return;
   }
 
+  //Get within four 16th notes of the next transition.
   if (!MidiClock.clock_less_than(MidiClock.div32th_counter + div32th_margin,
                                  (uint32_t)mcl_actions.next_transition * 2)) {
 
     DEBUG_PRINTLN("Preparing for next transition:");
     DEBUG_DUMP(MidiClock.div16th_counter);
     DEBUG_DUMP(mcl_actions.next_transition);
-
+    //Transition window
     div32th_counter = MidiClock.div32th_counter + div32th_margin;
   } else {
     return;
@@ -55,9 +56,9 @@ void GridTask::run() {
   for (uint8_t n = 0; n < NUM_TRACKS; n++) {
     slots_changed[n] = -1;
     if ((grid_page.active_slots[n] >= 0) && (mcl_actions.chains[n].loops > 0)) {
-      // mark slot as changed in case next statement doesnt pass
       uint32_t next_transition = (uint32_t)mcl_actions.next_transitions[n] * 2;
 
+      //If next_transition[n] is less than or equal to transition window, then flag track for transition.
       if (!MidiClock.clock_less_than(div32th_counter, next_transition)) {
 
         slots_changed[n] = mcl_actions.chains[n].row;

--- a/avr/cores/megacommand/MCL/GridTask.cpp
+++ b/avr/cores/megacommand/MCL/GridTask.cpp
@@ -139,6 +139,7 @@ void GridTask::run() {
 
           mcl_seq.ext_tracks[n - NUM_MD_TRACKS].start_step =
               mcl_actions.next_transition;
+          mcl_seq.ext_tracks[n - NUM_MD_TRACKS].start_step_offset = mcl_actions.transition_offsets[n];
           mcl_seq.ext_tracks[n - NUM_MD_TRACKS].mute_until_start = true;
           a4_track->load_seq_data(n - NUM_MD_TRACKS);
         } else {
@@ -240,6 +241,7 @@ void GridTask::run() {
           }
 
           mcl_seq.md_tracks[n].start_step = mcl_actions.next_transition;
+          mcl_seq.md_tracks[n].start_step_offset = mcl_actions.transition_offsets[n];
           mcl_seq.md_tracks[n].mute_until_start = true;
 
           md_track->load_seq_data(n);

--- a/avr/cores/megacommand/MCL/MCLActions.cpp
+++ b/avr/cores/megacommand/MCL/MCLActions.cpp
@@ -507,22 +507,26 @@ void MCLActions::calc_next_slot_transition(uint8_t n) {
   float len;
 
   if (n < NUM_MD_TRACKS) {
-    uint8_t l = mcl_seq.md_tracks[n].length;
-    len = chains[n].loops * (float) l * (float) mcl_seq.md_tracks[n].get_speed_multiplier();
+    float l = mcl_seq.md_tracks[n].length;
+    len = (float) chains[n].loops * l * (float) mcl_seq.md_tracks[n].get_speed_multiplier();
    }
 #ifdef EXT_TRACKS
   else {
-    uint8_t l = mcl_seq.ext_tracks[n - NUM_MD_TRACKS].length;
-    len = chains[n].loops * (float) l * (float) mcl_seq.ext_tracks[n - NUM_MD_TRACKS].get_speed_multiplier();
+    float l = mcl_seq.ext_tracks[n - NUM_MD_TRACKS].length;
+    len = (float) chains[n].loops * l * (float) mcl_seq.ext_tracks[n - NUM_MD_TRACKS].get_speed_multiplier();
             //( l - lm);
   }
 #endif
-
-  transition_offsets[n] = (float) (len - floor(len)) * 12;
-  DEBUG_DUMP(transition_offsets[n]);
   if (len < 4) {
     len = 4;
   }
+
+  //Last offset must be carried over to new offset.
+  transition_offsets[n] += (float) (len - floor(len)) * 12;
+  if (transition_offsets[n] >= 12) { transition_offsets[n] = transition_offsets[n] - 12; len++; }
+
+  DEBUG_DUMP(len - floor(len));
+  DEBUG_DUMP(transition_offsets[n]);
   next_transitions[n] += (uint16_t) len;
 
   // check for overflow and make sure next nearest step is greater than

--- a/avr/cores/megacommand/MCL/MCLActions.cpp
+++ b/avr/cores/megacommand/MCL/MCLActions.cpp
@@ -517,8 +517,9 @@ void MCLActions::calc_next_slot_transition(uint8_t n) {
             //( l - lm);
   }
 #endif
-  if (len < 4) {
-    len = 4;
+  while (len < 4) {
+    if (len < 1) { len = 4; transition_offsets[n] = 0; }
+    else { len = len * 2; }
   }
 
   //Last offset must be carried over to new offset.

--- a/avr/cores/megacommand/MCL/MCLActions.h
+++ b/avr/cores/megacommand/MCL/MCLActions.h
@@ -30,6 +30,7 @@ public:
   uint8_t nearest_beat;
 
   uint16_t next_transitions[NUM_TRACKS];
+  uint8_t transition_offsets[NUM_TRACKS];
   uint8_t send_machine[NUM_TRACKS];
   uint8_t transition_level[NUM_TRACKS];
 

--- a/avr/cores/megacommand/MCL/MCLActionsEvents.cpp
+++ b/avr/cores/megacommand/MCL/MCLActionsEvents.cpp
@@ -39,6 +39,7 @@ void MCLActionsCallbacks::onMidiStartCallback() {
   for (uint8_t n = 0; n < 20; n++) {
     if (grid_page.active_slots[n] >= 0) {
       mcl_actions.next_transitions[n] = 0;
+      mcl_actions.transition_offsets[n] = 0;
       if (mcl_cfg.chain_mode != 2) { mcl_actions.calc_next_slot_transition(n); }
     }
   }

--- a/avr/cores/megacommand/MCL/MDSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.cpp
@@ -57,13 +57,8 @@ void MDSeqTrack::seq() {
   if (mute_until_start) {
 
     if (clock_diff(MidiClock.div16th_counter, start_step) == 0) {
-      DEBUG_PRINTLN("unmuting");
-      DEBUG_PRINTLN(track_number);
-      DEBUG_PRINTLN(MidiClock.div16th_counter);
-      DEBUG_PRINTLN(start_step);
-      DEBUG_PRINTLN(MidiClock.mod12_counter);
-
-      reset();
+      if (start_step_offset > 0) { start_step_offset--; }
+      else { reset(); }
     }
   }
 

--- a/avr/cores/megacommand/MCL/MDSeqTrack.cpp
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.cpp
@@ -56,9 +56,12 @@ void MDSeqTrack::set_speed(uint8_t _speed) {
 void MDSeqTrack::seq() {
   if (mute_until_start) {
 
-    if (clock_diff(MidiClock.div16th_counter, start_step) == 0) {
-      if (start_step_offset > 0) { start_step_offset--; }
-      else { reset(); }
+    if ((clock_diff(MidiClock.div16th_counter, start_step) == 0)) {
+      if (start_step_offset > 0) {
+        start_step_offset--;
+      } else {
+        reset();
+      }
     }
   }
 

--- a/avr/cores/megacommand/MCL/MDSeqTrack.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.h
@@ -54,6 +54,7 @@ public:
   //  uint8_t params[24];
   uint8_t trigGroup;
   uint32_t start_step;
+  uint8_t start_step_offset;
 
   bool mute_until_start = false;
 

--- a/avr/cores/megacommand/MCL/MDSeqTrack.h
+++ b/avr/cores/megacommand/MCL/MDSeqTrack.h
@@ -57,6 +57,7 @@ public:
   uint8_t start_step_offset;
 
   bool mute_until_start = false;
+  bool mute_hold = false;
 
   uint8_t mute_state = SEQ_MUTE_OFF;
   void mute() { mute_state = SEQ_MUTE_ON; }
@@ -71,6 +72,7 @@ public:
     oneshot_mask = 0;
     mod12_counter = 0;
     mute_until_start = false;
+    mute_hold = false;
   }
 
   ALWAYS_INLINE() void seq();


### PR DESCRIPTION
Will likely need to rethink how track transitions works.
We currently calculate next transition in 16th step resolution.

This won't work for 3/2 and 3/4 tracks because they run at 0.75 and 1.5 speed.

For example:

Pattern length is 16 steps. At 3/4 speed, the next transition will occur on (1/0.75) * 16 == 21.333 steps.

Sequencer will go out of sync...

---

Proposed solution. Each track to have a transition_offset, measured in mod12 ticks. Transition start can be shifted by 0 -> 12 ticks 