### PR TITLE
seqpage/pageselectpage TI led

### DIFF
--- a/avr/cores/megacommand/MCL/GridSavePage.cpp
+++ b/avr/cores/megacommand/MCL/GridSavePage.cpp
@@ -145,6 +145,7 @@ bool GridSavePage::handleEvent(gui_event_t *event) {
   }
 
   if (note_interface.is_event(event)) {
+    trig_interface.send_md_leds();
     if (note_interface.notes_all_off()) {
       if (BUTTON_DOWN(Buttons.BUTTON2)) {
         return true;

--- a/avr/cores/megacommand/MCL/GridWritePage.cpp
+++ b/avr/cores/megacommand/MCL/GridWritePage.cpp
@@ -129,6 +129,7 @@ bool GridWritePage::handleEvent(gui_event_t *event) {
   DEBUG_DUMP(event->source);
   if (note_interface.is_event(event)) {
     DEBUG_PRINTLN("note event");
+    trig_interface.send_md_leds();
     if (note_interface.notes_all_off()) {
       DEBUG_PRINTLN("notes all off");
       if (BUTTON_DOWN(Buttons.BUTTON2)) {

--- a/avr/cores/megacommand/MCL/MCLGUI.cpp
+++ b/avr/cores/megacommand/MCL/MCLGUI.cpp
@@ -608,7 +608,7 @@ void MCLGUI::draw_trigs(uint8_t x, uint8_t y, uint8_t offset,
           oled_display.fillRect(x + 1, y + 1, seq_w - 1, trig_h - 1, WHITE);
         }
 
-    }
+      }
     }
 
     x += seq_w + 1;

--- a/avr/cores/megacommand/MCL/PageSelectPage.cpp
+++ b/avr/cores/megacommand/MCL/PageSelectPage.cpp
@@ -136,6 +136,8 @@ void PageSelectPage::init() {
   classic_display = false;
 #endif
   loop_init = true;
+  // clear trigled so it's always sent on first run
+  trigled_mask = 0;
   display();
 }
 
@@ -177,7 +179,7 @@ void PageSelectPage::cleanup() {
   MDSysexListener.removeOnKitMessageCallback(&kit_cb);
 #endif
   note_interface.init_notes();
-  MD.set_trigleds(0, TRIGLED_EXCLUSIVE);
+  MD.set_trigleds(0, TRIGLED_OVERLAY);
 }
 
 uint8_t PageSelectPage::get_nextpage_down() {

--- a/avr/cores/megacommand/MCL/PageSelectPage.cpp
+++ b/avr/cores/megacommand/MCL/PageSelectPage.cpp
@@ -177,6 +177,7 @@ void PageSelectPage::cleanup() {
   MDSysexListener.removeOnKitMessageCallback(&kit_cb);
 #endif
   note_interface.init_notes();
+  MD.set_trigleds(0, false);
 }
 
 uint8_t PageSelectPage::get_nextpage_down() {

--- a/avr/cores/megacommand/MCL/PageSelectPage.cpp
+++ b/avr/cores/megacommand/MCL/PageSelectPage.cpp
@@ -177,7 +177,7 @@ void PageSelectPage::cleanup() {
   MDSysexListener.removeOnKitMessageCallback(&kit_cb);
 #endif
   note_interface.init_notes();
-  MD.set_trigleds(0, false);
+  MD.set_trigleds(0, TRIGLED_EXCLUSIVE);
 }
 
 uint8_t PageSelectPage::get_nextpage_down() {
@@ -339,7 +339,7 @@ void PageSelectPage::display() {
   uint16_t led_mask = 1 << page_select;
   if (trigled_mask != led_mask) {
     trigled_mask = led_mask;
-    MD.set_trigleds(trigled_mask, false);
+    MD.set_trigleds(trigled_mask, TRIGLED_EXCLUSIVE);
   }
 }
 

--- a/avr/cores/megacommand/MCL/PageSelectPage.cpp
+++ b/avr/cores/megacommand/MCL/PageSelectPage.cpp
@@ -334,6 +334,12 @@ void PageSelectPage::display() {
   get_page(get_pageidx(page_select), str);
   GUI.put_string_at_fill(0, str);
 #endif
+
+  uint16_t led_mask = 1 << page_select;
+  if (trigled_mask != led_mask) {
+    trigled_mask = led_mask;
+    MD.set_trigleds(trigled_mask, false);
+  }
 }
 
 bool PageSelectPage::handleEvent(gui_event_t *event) {

--- a/avr/cores/megacommand/MCL/PageSelectPage.h
+++ b/avr/cores/megacommand/MCL/PageSelectPage.h
@@ -43,5 +43,6 @@ public:
 };
 
 extern PageSelectPage page_select_page;
+extern uint16_t trigled_mask;
 
 #endif /* PageSelectPAGE_H__ */

--- a/avr/cores/megacommand/MCL/SeqPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqPage.cpp
@@ -619,7 +619,7 @@ void SeqPage::draw_mask(uint8_t offset, uint8_t device,
 
     if (led_mask != trigled_mask) {
       trigled_mask = led_mask;
-      MD.set_trigleds(trigled_mask, true);
+      MD.set_trigleds(trigled_mask, TRIGLED_STEPEDIT);
     }
   }
 #ifdef EXT_TRACKS

--- a/avr/cores/megacommand/MCL/SeqPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqPage.cpp
@@ -24,6 +24,8 @@ uint8_t opt_shift = 0;
 uint8_t opt_reverse = 0;
 uint8_t opt_clear_step = 0;
 
+uint16_t trigled_mask = 0;
+
 static uint8_t opt_midi_device_capture = DEVICE_MD;
 static SeqPage *opt_seqpage_capture = nullptr;
 static MCLEncoder *opt_param1_capture = nullptr;
@@ -272,15 +274,12 @@ bool SeqPage::handleEvent(gui_event_t *event) {
     oled_display.clearDisplay();
     void (*row_func)();
     if (show_seq_menu) {
-      void (*row_func)() =
-          seq_menu_page.menu.get_row_function(seq_menu_page.encoders[1]->cur);
-
+      row_func = seq_menu_page.menu.get_row_function(seq_menu_page.encoders[1]->cur);
     } else if (show_step_menu) {
-      void (*row_func)() =
-          step_menu_page.menu.get_row_function(step_menu_page.encoders[1]->cur);
+      row_func = step_menu_page.menu.get_row_function(step_menu_page.encoders[1]->cur);
     }
     if (row_func != NULL) {
-      (*row_func)();
+      row_func();
       show_seq_menu = false;
       show_step_menu = false;
       return true;
@@ -595,22 +594,33 @@ void SeqPage::draw_mask(uint8_t offset, uint8_t device,
     uint64_t mask = active_track.pattern_mask;
     uint64_t oneshot_mask = 0;
     uint64_t slide_mask = 0;
+    uint16_t led_mask = 0; 
+
 
     switch (mask_type) {
     case MASK_PATTERN:
+      led_mask = mask >> offset;
       break;
     case MASK_LOCK:
+      led_mask = active_track.lock_mask >> offset;
       break;
     case MASK_MUTE:
       oneshot_mask = active_track.oneshot_mask;
+      led_mask = oneshot_mask >> offset;
       break;
     case MASK_SLIDE:
       slide_mask = active_track.slide_mask;
+      led_mask = slide_mask >> offset;
       break;
     }
 
     draw_mask(offset, mask, active_track.step_count, active_track.length,
               show_current_step, oneshot_mask, slide_mask);
+
+    if (led_mask != trigled_mask) {
+      trigled_mask = led_mask;
+      MD.set_trigleds(trigled_mask, true);
+    }
   }
 #ifdef EXT_TRACKS
   else {

--- a/avr/cores/megacommand/MCL/SeqPage.h
+++ b/avr/cores/megacommand/MCL/SeqPage.h
@@ -26,6 +26,8 @@ extern uint8_t opt_shift;
 extern uint8_t opt_reverse;
 extern uint8_t opt_clear_step;
 
+extern uint16_t trigled_mask;
+
 extern void opt_trackid_handler();
 extern void opt_speed_handler();
 extern void opt_clear_track_handler();

--- a/avr/cores/megacommand/MCL/SeqParamPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqParamPage.cpp
@@ -208,7 +208,7 @@ bool SeqParamPage::handleEvent(gui_event_t *event) {
     uint8_t device = midi_active_peering.get_device(port);
 
     uint8_t track = event->source - 128;
-
+    uint64_t *seq_mask = &(mcl_seq.md_tracks[last_md_track].lock_mask);
     if (device == DEVICE_A4) {
       return true;
     }
@@ -221,6 +221,11 @@ bool SeqParamPage::handleEvent(gui_event_t *event) {
 
       seq_lock1.cur = mcl_seq.md_tracks[last_md_track].locks[p1][step] - 1;
       seq_lock2.cur = mcl_seq.md_tracks[last_md_track].locks[p2][step] - 1;
+
+      if (!IS_BIT_SET64_P(seq_mask, step)) {
+        SET_BIT64_P(seq_mask, step);
+        note_interface.ignoreNextEvent(track);
+      }
     }
     if (event->mask == EVENT_BUTTON_RELEASED) {
       if (device == DEVICE_A4) {
@@ -238,12 +243,12 @@ if (utiming == 0) {
   mcl_seq.md_tracks[last_md_track].conditional[step] = condition;
   mcl_seq.md_tracks[last_md_track].timing[step] = utiming;
 }*/
-      if (IS_BIT_SET64(mcl_seq.md_tracks[last_md_track].lock_mask, step)) {
+      if (IS_BIT_SET64_P(seq_mask, step)) {
         if (clock_diff(note_interface.note_hold, slowclock) < TRIG_HOLD_TIME) {
-          CLEAR_BIT64(mcl_seq.md_tracks[last_md_track].lock_mask, step);
+          CLEAR_BIT64_P(seq_mask, step);
         }
       } else {
-        SET_BIT64(mcl_seq.md_tracks[last_md_track].lock_mask, step);
+        SET_BIT64_P(seq_mask, step);
       }
       /*
             mcl_seq.md_tracks[last_md_track].locks[p1][step] =

--- a/avr/cores/megacommand/MCL/SeqParamPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqParamPage.cpp
@@ -247,8 +247,6 @@ if (utiming == 0) {
         if (clock_diff(note_interface.note_hold, slowclock) < TRIG_HOLD_TIME) {
           CLEAR_BIT64_P(seq_mask, step);
         }
-      } else {
-        SET_BIT64_P(seq_mask, step);
       }
       /*
             mcl_seq.md_tracks[last_md_track].locks[p1][step] =

--- a/avr/cores/megacommand/MCL/SeqStepPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqStepPage.cpp
@@ -326,19 +326,7 @@ bool SeqStepPage::handleEvent(gui_event_t *event) {
         mcl_seq.midi_events.update_params = true;
         MD.midi_events.enable_live_kit_update();
       }
-      if (!IS_BIT_SET64_P(seq_mask, step)) {
-        uint8_t utiming = (seq_param2.cur + 0);
-        uint8_t condition = translate_to_step_conditional(seq_param1.cur);
-
-        DEBUG_PRINTLN("settting");
-
-        active_track.conditional[step] = condition;
-        active_track.timing[step] = utiming;
-        if (clock_diff(note_interface.note_hold, slowclock) < TRIG_HOLD_TIME) {
-        CLEAR_BIT64(active_track.oneshot_mask, step);
-        SET_BIT64_P(seq_mask, step);
-        }
-      } else {
+      if (IS_BIT_SET64_P(seq_mask, step)) {
         DEBUG_PRINTLN("clear step");
 
         if (clock_diff(note_interface.note_hold, slowclock) < TRIG_HOLD_TIME) {

--- a/avr/cores/megacommand/MCL/SeqStepPage.cpp
+++ b/avr/cores/megacommand/MCL/SeqStepPage.cpp
@@ -275,7 +275,7 @@ bool SeqStepPage::handleEvent(gui_event_t *event) {
       int8_t utiming = active_track.timing[step];
       uint8_t pitch = active_track.get_track_lock(step, 0) - 1;
       // Cond
-      uint8_t condition = translate_to_knob_conditional(active_track.conditional[step]); 
+      uint8_t condition = translate_to_knob_conditional(active_track.conditional[step]);
       seq_param1.cur = condition;
       uint8_t note_num = 255;
 
@@ -301,6 +301,13 @@ bool SeqStepPage::handleEvent(gui_event_t *event) {
       }
       seq_param2.cur = utiming;
       seq_param2.old = utiming;
+      if (!IS_BIT_SET64_P(seq_mask, step)) {
+        active_track.conditional[step] = condition;
+        active_track.timing[step] = utiming;
+        CLEAR_BIT64(active_track.oneshot_mask, step);
+        SET_BIT64_P(seq_mask, step);
+        note_interface.ignoreNextEvent(trackid);
+      }
       //      }
     }
 

--- a/avr/cores/megacommand/MCL/TrigInterface.cpp
+++ b/avr/cores/megacommand/MCL/TrigInterface.cpp
@@ -7,6 +7,16 @@ void TrigInterface::start() {
 
 }
 
+void TrigInterface::send_md_leds() {
+    uint16_t led_mask = 0;
+    for (uint8_t i = 0; i < 16; i++) {
+      if (note_interface.notes[i] == 1) {
+        SET_BIT16(led_mask, i);
+      }
+    }
+    MD.set_trigleds(led_mask, false);
+}
+
 bool TrigInterface::on() {
 
   if (state) {

--- a/avr/cores/megacommand/MCL/TrigInterface.cpp
+++ b/avr/cores/megacommand/MCL/TrigInterface.cpp
@@ -14,7 +14,7 @@ void TrigInterface::send_md_leds() {
         SET_BIT16(led_mask, i);
       }
     }
-    MD.set_trigleds(led_mask, false);
+    MD.set_trigleds(led_mask, TRIGLED_OVERLAY);
 }
 
 bool TrigInterface::on() {

--- a/avr/cores/megacommand/MCL/TrigInterface.h
+++ b/avr/cores/megacommand/MCL/TrigInterface.h
@@ -23,6 +23,7 @@ public:
   virtual void start();
   virtual void end();
   virtual void end_immediate();
+  void send_md_leds();
   void cleanup();
   /* @} */
 };

--- a/avr/cores/megacommand/MD/MD.cpp
+++ b/avr/cores/megacommand/MD/MD.cpp
@@ -204,15 +204,14 @@ void MDClass::deactivate_track_select() {
   sendRequest(data, sizeof(data));
 }
 
-void MDClass::set_trigleds(uint16_t bitmask, bool recmode) {
+void MDClass::set_trigleds(uint16_t bitmask, TrigLEDMode mode) {
   uint8_t data[5] = {0x70, 0x35, 0x00, 0x00, 0x00};
   // trigleds[0..6]
   data[2] = bitmask & 0x7F;
   // trigleds[7..13]
   data[3] = (bitmask >> 7) & 0x7F;
   // trigleds[14..15]
-  data[4] = (bitmask >> 14) ;
-  if (recmode) { data[4] |= 0x4; }
+  data[4] = (bitmask >> 14) | (mode << 2);
   sendRequest(data, sizeof(data));
 }
 

--- a/avr/cores/megacommand/MD/MD.cpp
+++ b/avr/cores/megacommand/MD/MD.cpp
@@ -204,24 +204,15 @@ void MDClass::deactivate_track_select() {
   sendRequest(data, sizeof(data));
 }
 
-void MDClass::set_leds_batch(uint16_t bitmask) {
+void MDClass::set_trigleds(uint16_t bitmask, bool recmode) {
   uint8_t data[5] = {0x70, 0x35, 0x00, 0x00, 0x00};
-  data[2] = bitmask >> 9;
-  data[3] = (bitmask >> 3) & 0x7F;
-  data[4] = (bitmask << 5) & 0x7F;
-  sendRequest(data, sizeof(data));
-}
-
-void MDClass::set_led(uint8_t idx) {
-
-  uint8_t data[3] = {0x70, 0x34, 0x00};
-  data[2] = idx + 0x40;
-  sendRequest(data, sizeof(data));
-}
-
-void MDClass::clear_led(uint8_t idx) {
-  uint8_t data[3] = {0x70, 0x34, 0x00};
-  data[2] = idx;
+  // trigleds[0..6]
+  data[2] = bitmask & 0x7F;
+  // trigleds[7..13]
+  data[3] = (bitmask >> 7) & 0x7F;
+  // trigleds[14..15]
+  data[4] = (bitmask >> 14) ;
+  if (recmode) { data[4] |= 0x4; }
   sendRequest(data, sizeof(data));
 }
 

--- a/avr/cores/megacommand/MD/MD.h
+++ b/avr/cores/megacommand/MD/MD.h
@@ -256,9 +256,7 @@ public:
   void activate_track_select();
   void deactivate_track_select();
 
-  void set_leds_batch(uint16_t bitmask);
-  void set_led(uint8_t idx);
-  void clear_led(uint8_t idx);
+  void set_trigleds(uint16_t bitmask, bool recmode);
   /**
    * Get the actual PITCH value for the MIDI pitch for the given
    * track. If the track is melodic, this will lookup the actual PITCH

--- a/avr/cores/megacommand/MD/MD.h
+++ b/avr/cores/megacommand/MD/MD.h
@@ -131,6 +131,11 @@ public:
   void onNoteOnCallback_Midi(uint8_t *msg);
 };
 
+enum TrigLEDMode {
+  TRIGLED_OVERLAY = 0,
+  TRIGLED_STEPEDIT = 1,
+  TRIGLED_EXCLUSIVE = 2
+};
 
 /**
  * This is the main class used to communicate with a Machinedrum
@@ -256,7 +261,7 @@ public:
   void activate_track_select();
   void deactivate_track_select();
 
-  void set_trigleds(uint16_t bitmask, bool recmode);
+  void set_trigleds(uint16_t bitmask, TrigLEDMode mode);
   /**
    * Get the actual PITCH value for the MIDI pitch for the given
    * track. If the track is melodic, this will lookup the actual PITCH


### PR DESCRIPTION
Requires https://github.com/yatli/mdhack/pull/20

Demonstrates two TI trigled modes: normal and rec.

PageSelectPage uses the normal mode to show the current selected page. Playing notes will be displayed on the TI.
SeqPage uses the rec mode to show MCL mask data plus the current playing cursor.