### PR TITLE
fix(md): mirror MD-bound CCs from MidiUSB/Midi2 into kit cache

### DIFF
--- a/src/mcl/MD/MD.cpp
+++ b/src/mcl/MD/MD.cpp
@@ -7,12 +7,26 @@
 #include "MDTrackSelect.h"
 #include "SeqPages.h"
 
+// Ports we mirror MD-bound CCs into MD.kit from. Includes MidiUSB and Midi2
+// so external controllers / DAWs whose CCs are forwarded to the MD keep
+// MCL's kit cache in sync, otherwise reset_params() on transport stop will
+// overwrite the live MD state with stale cache.
+static MidiClass *const kit_update_ports[] = {&Midi, &MidiUSB, &Midi2};
+static constexpr uint8_t kit_update_port_count =
+    sizeof(kit_update_ports) / sizeof(kit_update_ports[0]);
+
 void MDMidiEvents::onControlChangeCallback_Midi(uint8_t *msg) {
   uint8_t channel = MIDI_VOICE_CHANNEL(msg[0]);
   uint8_t param = msg[1];
   uint8_t value = msg[2];
   uint8_t track;
   uint8_t track_param;
+
+  // Only mirror CCs that land on one of the MD's four base channels.
+  uint8_t md_channel_offset = channel - MD.global.baseChannel;
+  if (md_channel_offset >= 4) {
+    return;
+  }
 
   MD.parseCC(channel, param, &track, &track_param);
   if (track == 255) {
@@ -30,7 +44,10 @@ void MDMidiEvents::onControlChangeCallback_Midi(uint8_t *msg) {
     last_md_param = track_param;
   } else {
     if (param > 7 && param < 12) {
-      track = param - 8 + (channel - MD.global.baseChannel) * 4;
+      track = (param - 8) + md_channel_offset * 4;
+      if (track > 15) {
+        return;
+      }
       MD.kit.levels[track] = value;
     }
   }
@@ -44,8 +61,11 @@ void MDMidiEvents::enable_live_kit_update() {
   if (kitupdate_state) {
     return;
   }
-  Midi.addOnControlChangeCallback(
-      this, (midi_callback_ptr_t)&MDMidiEvents::onControlChangeCallback_Midi);
+  for (uint8_t i = 0; i < kit_update_port_count; ++i) {
+    kit_update_ports[i]->addOnControlChangeCallback(
+        this,
+        (midi_callback_ptr_t)&MDMidiEvents::onControlChangeCallback_Midi);
+  }
   kitupdate_state = true;
 }
 
@@ -54,8 +74,11 @@ void MDMidiEvents::disable_live_kit_update() {
   if (!kitupdate_state) {
     return;
   }
-  Midi.removeOnControlChangeCallback(
-      this, (midi_callback_ptr_t)&MDMidiEvents::onControlChangeCallback_Midi);
+  for (uint8_t i = 0; i < kit_update_port_count; ++i) {
+    kit_update_ports[i]->removeOnControlChangeCallback(
+        this,
+        (midi_callback_ptr_t)&MDMidiEvents::onControlChangeCallback_Midi);
+  }
   kitupdate_state = false;
 }
 


### PR DESCRIPTION
## Summary

- `MDMidiEvents::onControlChangeCallback_Midi` is registered only on `Midi` (UART1, the MD's own port), so MD-bound CCs arriving on `MidiUSB` or `Midi2` (e.g. an external controller or DAW whose CCs are forwarded to the MD) never update MCL's `MD.kit` cache.
- On transport stop, `MCLSeq::onMidiStopCallback` runs `MDSeqTrack::reset_params()` for every MD track, which re-sends the cached kit via `MD.assignMachineBulk(...)`. With a stale cache this overwrites the live MD state — the user's controller edits get wiped on every stop.
- This PR subscribes the kit-update callback on all three MIDI ports (`Midi`, `MidiUSB`, `Midi2`) via a small port table, and adds two safety guards in the handler so it tolerates traffic on non-MD channels:
  - Early-return when the CC's channel is outside the MD's four base channels.
  - Bounds-check the level-CC track index before writing into `MD.kit.levels[]`.

## Repro

1. Set `Ctrl Port = USB`, route a USB controller through MCL to MD on the MD's base channel.
2. Turn knobs on the controller — MD responds (good).
3. Stop the transport (external master, MD, or DAW sending `MIDI_STOP` to MCL).
4. Without the fix, MCL's `reset_params()` re-sends the stale cached kit, reverting all controller edits.
5. With the fix, the cache stays in sync and the live edits survive.

Direct edits on the MD already work, because the MD echoes its own knob movements as CC on UART1, which the existing `Midi` listener handles — the asymmetry was that USB/DIN CCs forwarded *to* the MD never made it into MCL's cache.

## Test plan

- [x] Builds clean for `megacmd` (AVR ATmega2560), no new warnings or errors.
- [ ] On hardware: USB-controller param edits persist across transport stop/start.
- [ ] On hardware: existing front-panel and direct-MD edit behavior unchanged.
- [ ] On hardware: traffic on non-MD channels (ext tracks, MNM/A4 on UART2) does not spuriously update `MD.kit`.

## Notes

- Single-file change, `src/mcl/MD/MD.cpp` (+28 / -5).
- The level-CC bounds check is a latent fix: the previous code computed `track = (param - 8) + (channel - MD.global.baseChannel) * 4` with no upper bound, which was tolerable when only `Midi` carried this listener but would be an out-of-range write into `MD.kit.levels[]` once the listener is also bound to `MidiUSB`/`Midi2`.